### PR TITLE
fix SSL issue in proxy

### DIFF
--- a/src/main/java/net/sourceforge/plantuml/servlet/ProxyServlet.java
+++ b/src/main/java/net/sourceforge/plantuml/servlet/ProxyServlet.java
@@ -65,8 +65,6 @@ public class ProxyServlet extends HttpServlet {
         final String index = request.getParameter("idx");
         final URL srcUrl;
 
-        System.setProperty("jsse.enableSNIExtension", "false");
-
         // Check if the src URL is valid
         try {
             srcUrl = new URL(source);
@@ -102,6 +100,9 @@ public class ProxyServlet extends HttpServlet {
         String line;
         BufferedReader rd;
         StringBuilder sb;
+
+        String sni = System.getProperty("jsse.enableSNIExtension", "false");
+        System.setProperty("jsse.enableSNIExtension", "false");
         try {
             HttpURLConnection con = getConnection(url);
             rd = new BufferedReader(new InputStreamReader(con.getInputStream()));
@@ -111,11 +112,13 @@ public class ProxyServlet extends HttpServlet {
                 sb.append(line + '\n');
             }
             rd.close();
+            System.setProperty("jsse.enableSNIExtension", sni);
             return sb.toString();
         } catch (IOException e) {
             e.printStackTrace();
         } finally {
             rd = null;
+            System.setProperty("jsse.enableSNIExtension", sni);
         }
         return "";
     }


### PR DESCRIPTION
when fetching diagrams from SSL Endpoints, handshake may fail in java >= 1.7 with
"javax.net.ssl.SSLProtocolException: handshake alert: unrecognized_name"

this patch disables SNI Extension. proxy now works for https://raw.githubusercontent.com/some/privatepage?login=user%26token=some2143token

it is a quick fix to show the issue and hint for the root cause. 
please advise how this should be implemented.
