### PR TITLE
Add missing graphviz

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,6 @@
 FROM maven:3-jdk-8
 
+RUN apt-get update && apt-get install -y --no-install-recommends graphviz && rm -rf /var/lib/apt/lists/*
 ADD . /app
 WORKDIR /app
 EXPOSE 8080


### PR DESCRIPTION
Some diagrams needs the `graphviz`.

You can test it by:
```
@startuml
testdot
@enduml
```