### PR TITLE
Renamed tomcat8 dockerfile to match README

### DIFF
--- a/Dockerfile.tomcat
+++ b/Dockerfile.tomcat
@@ -1,4 +1,0 @@
-# Dockerfile
-FROM tomcat:8
-RUN apt-get update && apt-get install -y --no-install-recommends graphviz fonts-wqy-zenhei && rm -rf /var/lib/apt/lists/*
-ADD target/*.war /usr/local/tomcat/webapps/

--- a/Dockerfile.tomcat8
+++ b/Dockerfile.tomcat8
@@ -1,0 +1,4 @@
+# Dockerfile
+FROM tomcat:8
+RUN apt-get update && apt-get install -y --no-install-recommends graphviz fonts-wqy-zenhei && rm -rf /var/lib/apt/lists/*
+ADD target/*.war /usr/local/tomcat/webapps/


### PR DESCRIPTION
Hi, Arnaud, I renamed the dockerfile to match the instructions in the README.

> Dockerfile.tomcat → Dockerfile.tomcat8

 I initially thought of updating the instructions instead, but then if we get a different file for the next version of tomcat, this made better sense

Thank you