### PR TITLE
Allow running on the Openshift platform

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,20 @@
 FROM maven:3-jdk-8
 
 RUN apt-get update && apt-get install -y --no-install-recommends graphviz fonts-wqy-zenhei && rm -rf /var/lib/apt/lists/*
-ADD . /app
+
+COPY pom.xml /app/
+COPY src /app/src/
+
+ENV MAVEN_CONFIG=/app/.m2
 WORKDIR /app
+RUN mvn package
+
+# chmod required to ensure any user can run the app
+RUN mkdir /app/.m2 && chmod -R a+w /app
 EXPOSE 8080
-CMD ["mvn", "jetty:run"]
+ENV HOME /app
+
+CMD java -Djetty.contextpath=/ -jar target/dependency/jetty-runner.jar target/plantuml.war
+
+# To run with debugging enabled instead
+#CMD java -Dorg.eclipse.jetty.util.log.class=org.eclipse.jetty.util.log.StdErrLog -Dorg.eclipse.jetty.LEVEL=DEBUG -Djetty.contextpath=/ -jar target/dependency/jetty-runner.jar target/plantuml.war

--- a/pom.xml
+++ b/pom.xml
@@ -32,7 +32,7 @@
         <configuration>
           <scanIntervalSeconds>5</scanIntervalSeconds>
           <webApp>
-            <contextPath>/plantuml</contextPath>
+            <contextPath>${jetty.contextpath}</contextPath>
           </webApp>
           <systemProperties>
             <systemProperty>
@@ -42,6 +42,27 @@
           </systemProperties>
         </configuration>
       </plugin>
+        <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-dependency-plugin</artifactId>
+            <version>2.3</version>
+            <executions>
+                <execution>
+                    <phase>package</phase>
+                    <goals><goal>copy</goal></goals>
+                    <configuration>
+                        <artifactItems>
+                            <artifactItem>
+                                <groupId>org.mortbay.jetty</groupId>
+                                <artifactId>jetty-runner</artifactId>
+                                <version>8.1.9.v20130131</version>
+                                <destFileName>jetty-runner.jar</destFileName>
+                            </artifactItem>
+                        </artifactItems>
+                    </configuration>
+                </execution>
+            </executions>
+        </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-war-plugin</artifactId>
@@ -149,6 +170,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <jetty.version>8.0.4.v20111024</jetty.version>
     <jetty.port>8080</jetty.port>
+    <jetty.contextpath>/plantuml</jetty.contextpath>
     <maven.build.timestamp.format>yyyyMMdd-HHmm
     </maven.build.timestamp.format>
     <timestamp>${maven.build.timestamp}</timestamp>


### PR DESCRIPTION
A few changes are necessary for the best out-of-the-box experience on Docker-based application
platforms such as OpenShift:
1. For security purposes, they run the containers as non-root. Before this change, the user was
   trying to write to the home dir, which is set to /root by default.
2. Deploy time is limited, and the download of dependencies by Jetty at start-up time, while
   convenient for testing, causes timeouts when deploying. a WAR is now created during
   Docker image creation, and as a result starting up the container is really fast now.

In addition, it is now possible to enable debug logging for Jetty by uncommenting the
relevant line in the Dockerfile.