### PR TITLE
Support EPS and EPS text output

### DIFF
--- a/src/main/java/net/sourceforge/plantuml/servlet/DiagramResponse.java
+++ b/src/main/java/net/sourceforge/plantuml/servlet/DiagramResponse.java
@@ -61,6 +61,7 @@ class DiagramResponse {
         Map<FileFormat, String> map = new HashMap<FileFormat, String>();
         map.put(FileFormat.PNG, "image/png");
         map.put(FileFormat.SVG, "image/svg+xml");
+        map.put(FileFormat.EPS, "application/postscript");
         map.put(FileFormat.UTXT, "text/plain;charset=UTF-8");
         CONTENT_TYPE = Collections.unmodifiableMap(map);
     }

--- a/src/main/java/net/sourceforge/plantuml/servlet/EpsServlet.java
+++ b/src/main/java/net/sourceforge/plantuml/servlet/EpsServlet.java
@@ -1,0 +1,40 @@
+/* ========================================================================
+ * PlantUML : a free UML diagram generator
+ * ========================================================================
+ *
+ * Project Info:  http://plantuml.sourceforge.net
+ *
+ * This file is part of PlantUML.
+ *
+ * PlantUML is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PlantUML distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301,
+ * USA.
+ */
+package net.sourceforge.plantuml.servlet;
+
+import net.sourceforge.plantuml.FileFormat;
+
+/*
+ * EPS servlet of the webapp.
+ * This servlet produces the UML diagram in EPS format.
+ */
+@SuppressWarnings("serial")
+public class EpsServlet extends UmlDiagramService {
+
+    @Override
+    public FileFormat getOutputFormat() {
+        return FileFormat.EPS;
+    }
+
+}

--- a/src/main/java/net/sourceforge/plantuml/servlet/EpsTextServlet.java
+++ b/src/main/java/net/sourceforge/plantuml/servlet/EpsTextServlet.java
@@ -1,0 +1,40 @@
+/* ========================================================================
+ * PlantUML : a free UML diagram generator
+ * ========================================================================
+ *
+ * Project Info:  http://plantuml.sourceforge.net
+ *
+ * This file is part of PlantUML.
+ *
+ * PlantUML is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PlantUML distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301,
+ * USA.
+ */
+package net.sourceforge.plantuml.servlet;
+
+import net.sourceforge.plantuml.FileFormat;
+
+/*
+ * EPS servlet of the webapp.
+ * This servlet produces the UML diagram in EPS format.
+ */
+@SuppressWarnings("serial")
+public class EpsTextServlet extends UmlDiagramService {
+
+    @Override
+    public FileFormat getOutputFormat() {
+        return FileFormat.EPS_TEXT;
+    }
+
+}

--- a/src/main/java/net/sourceforge/plantuml/servlet/OldProxyServlet.java
+++ b/src/main/java/net/sourceforge/plantuml/servlet/OldProxyServlet.java
@@ -110,6 +110,12 @@ public class OldProxyServlet extends HttpServlet {
         if (format.equals("svg")) {
             return FileFormat.SVG;
         }
+        if (format.equals("eps")) {
+            return FileFormat.EPS;
+        }
+        if (format.equals("epstext")) {
+            return FileFormat.EPS_TEXT;
+        }
         if (format.equals("txt")) {
             return FileFormat.ATXT;
         }

--- a/src/main/java/net/sourceforge/plantuml/servlet/ProxyServlet.java
+++ b/src/main/java/net/sourceforge/plantuml/servlet/ProxyServlet.java
@@ -122,6 +122,12 @@ public class ProxyServlet extends HttpServlet {
         if (format.equals("svg")) {
             return FileFormat.SVG;
         }
+        if (format.equals("eps")) {
+            return FileFormat.EPS;
+        }
+        if (format.equals("epstext")) {
+            return FileFormat.EPS_TEXT;
+        }
         if (format.equals("txt")) {
             return FileFormat.UTXT;
         }

--- a/src/main/java/net/sourceforge/plantuml/servlet/diagrams.txt
+++ b/src/main/java/net/sourceforge/plantuml/servlet/diagrams.txt
@@ -20,6 +20,8 @@ abstract HttpServlet <|-- MapServlet
 abstract HttpServlet <|-- ProxyServlet
 UmlDiagramService <|-- PngServlet
 UmlDiagramService <|-- SvgServlet
+UmlDiagramService <|-- EpsServlet
+UmlDiagramService <|-- EpsTextServlet
 UmlDiagramService <|-- AsciiServlet
 UmlDiagramService o- DiagramResponse
 MapServlet o-- DiagramResponse

--- a/src/main/java/net/sourceforge/plantuml/servlet/package.html
+++ b/src/main/java/net/sourceforge/plantuml/servlet/package.html
@@ -3,7 +3,7 @@
 <p>This package is in charge of the JEE PlantUml Server.</p>
 <p>there are 2 kind of servlets in this package :<br>
 - Interactive servlets : Welcome, PlantUmlServlet that are in charge of the web pages dedicated to human users.<br>
-- Service servlets : ImgServlet, SvgServlet, AsciiServlet, ProxyServlet that only produce a diagram as output.<br>
+- Service servlets : ImgServlet, SvgServlet, EpsServlet, EpsTextServlet, AsciiServlet, ProxyServlet that only produce a diagram as output.<br>
 <br>
 Structure of the service part of the PlantUmlServer: <br>
 <img src="http://www.plantuml.com/plantuml/img/XP51ReCm44Ntd6AMH0etwAPIbNPJjIhg0OoPm4WsTiPZrAZDtGk5913IP3b_dlx_7jTK8g3riWUBja0EIJsLf7RbJDeIcavHHH1MMa0R5G9yMlD4gc9bS-IMDC9t0k1ZOKX3wwY4qZsZf2yYlYSCoWVk8WO1tgrX9WVlce30mQywZrFGQ9OBKrD1XPAxo1hJenAPPlo636uSMoKz_1R5HndcT9KSag7tMFeKshU-qDBhxTRJW6sV_FVCW4qv6foRMJFRloe_tntEvvnamSDFbYqlUuFjZCVv1lJExcj_n9R_DZ1DTOV8stl4Oz14_pCkkpnqSgxVRPVhQV5hm2y0" />

--- a/src/main/webapp/WEB-INF/web.xml
+++ b/src/main/webapp/WEB-INF/web.xml
@@ -24,6 +24,14 @@
 		<servlet-class>net.sourceforge.plantuml.servlet.SvgServlet</servlet-class>
 	</servlet>
 	<servlet>
+		<servlet-name>epsservlet</servlet-name>
+		<servlet-class>net.sourceforge.plantuml.servlet.EpsServlet</servlet-class>
+	</servlet>
+	<servlet>
+		<servlet-name>epstextservlet</servlet-name>
+		<servlet-class>net.sourceforge.plantuml.servlet.EpsTextServlet</servlet-class>
+	</servlet>
+	<servlet>
 		<servlet-name>asciiservlet</servlet-name>
 		<servlet-class>net.sourceforge.plantuml.servlet.AsciiServlet</servlet-class>
 	</servlet>
@@ -34,7 +42,7 @@
     <servlet>
         <servlet-name>oldproxyservlet</servlet-name>
         <servlet-class>net.sourceforge.plantuml.servlet.OldProxyServlet</servlet-class>
-    </servlet>    
+    </servlet>
     <servlet>
         <servlet-name>mapservlet</servlet-name>
         <servlet-class>net.sourceforge.plantuml.servlet.MapServlet</servlet-class>
@@ -67,6 +75,14 @@
 	<servlet-mapping>
 		<servlet-name>svgservlet</servlet-name>
 		<url-pattern>/svg/*</url-pattern>
+	</servlet-mapping>
+	<servlet-mapping>
+		<servlet-name>epsservlet</servlet-name>
+		<url-pattern>/eps/*</url-pattern>
+	</servlet-mapping>
+	<servlet-mapping>
+		<servlet-name>epstextservlet</servlet-name>
+		<url-pattern>/epstext/*</url-pattern>
 	</servlet-mapping>
 	<servlet-mapping>
 		<servlet-name>asciiservlet</servlet-name>

--- a/src/test/java/net/sourceforge/plantuml/servlet/AllTests.java
+++ b/src/test/java/net/sourceforge/plantuml/servlet/AllTests.java
@@ -12,6 +12,7 @@ public class AllTests extends TestSuite {
         suite.addTestSuite(TestImage.class);
         suite.addTestSuite(TestAsciiArt.class);
         suite.addTestSuite(TestSVG.class);
+        suite.addTestSuite(TestEPS.class);
         suite.addTestSuite(TestProxy.class);
         suite.addTestSuite(TestMap.class);
         suite.addTestSuite(TestCharset.class);

--- a/src/test/java/net/sourceforge/plantuml/servlet/TestEPS.java
+++ b/src/test/java/net/sourceforge/plantuml/servlet/TestEPS.java
@@ -1,0 +1,27 @@
+package net.sourceforge.plantuml.servlet;
+
+import com.meterware.httpunit.GetMethodWebRequest;
+import com.meterware.httpunit.WebConversation;
+import com.meterware.httpunit.WebRequest;
+import com.meterware.httpunit.WebResponse;
+
+import java.util.Scanner;
+
+public class TestEPS extends WebappTestCase {
+    /**
+     * Verifies the generation of the EPS for the Bob -> Alice sample
+     */
+    public void testSimpleSequenceDiagram() throws Exception {
+        WebConversation conversation = new WebConversation();
+        WebRequest request = new GetMethodWebRequest(getServerUrl() + "eps/" + TestUtils.SEQBOB);
+        WebResponse response = conversation.getResource(request);
+        // Analyze response
+        // Verifies the Content-Type header
+        assertEquals("Response content type is not EPS", "application/postscript", response.getContentType());
+        // Get the content and verify its size
+        String diagram = response.getText();
+        int diagramLen = diagram.length();
+        assertTrue(diagramLen > 10000);
+        assertTrue(diagramLen < 12000);
+    }
+}


### PR DESCRIPTION
This MR allows a user to request EPS or EPS with text output, fixes #47.

The URLs for different output formats are:
- PNG: `http://plantumlserver/plantuml/png/[ENCODED_UML]`
- SVG: `http://plantumlserver/plantuml/svg/[ENCODED_UML]`
- EPS (new) `http://plantumlserver/plantuml/eps/[ENCODED_UML]`
- EPS with text (new) `http://plantumlserver/plantuml/epstext/[ENCODED_UML]`

The proxy server has also been updated to support `&fmt=eps` and `&fmt=epstext` query parameters.

Regarding the tests: I was not able to run any of the test cases sucessfully, so I can not check if the test for EPS works correctly.
Currently it checks mime type and size, but not the actual contents of the diagram, which is not trivial.