### PR TITLE
Upgrade way to build docker image

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,9 +5,6 @@ sudo: required
 services:
     - docker
 
-script:
-    - mvn package
-
 after_success:
   - docker login  -u $DOCKER_LOGIN -p $DOCKER_PASSWORD
   - if [ "$TRAVIS_BRANCH" == "master" ]; then
@@ -19,5 +16,8 @@ after_success:
     docker push plantuml/plantuml-server:tomcat;
     docker push plantuml/plantuml-server:jetty;
     docker push plantuml/plantuml-server:latest;
+
+    docker build -t plantuml/plantuml-server:armv8a -f Dockerfile.armv8a . ;
+    docker push plantuml/plantuml-server:armv8a;
 
     fi

--- a/Dockerfile.jetty
+++ b/Dockerfile.jetty
@@ -1,3 +1,16 @@
+FROM maven:3-jdk-8 AS builder
+
+RUN apt-get update && apt-get install -y --no-install-recommends graphviz fonts-wqy-zenhei && rm -rf /var/lib/apt/lists/*
+
+COPY pom.xml /app/
+COPY src /app/src/
+
+ENV MAVEN_CONFIG=/app/.m2
+WORKDIR /app
+RUN mvn package
+
+########################################################################################
+
 FROM jetty
 MAINTAINER D.Ducatel
 
@@ -5,4 +18,6 @@ RUN apt-get update && \
     apt-get install -y --no-install-recommends graphviz fonts-wqy-zenhei && \
     rm -rf /var/lib/apt/lists/*
 
-ADD target/plantuml.war /var/lib/jetty/webapps/ROOT.war
+COPY --from=builder /app/target/plantuml.war /var/lib/jetty/webapps/ROOT.war
+
+

--- a/Dockerfile.tomcat
+++ b/Dockerfile.tomcat
@@ -1,3 +1,16 @@
+FROM maven:3-jdk-8 AS builder
+
+RUN apt-get update && apt-get install -y --no-install-recommends graphviz fonts-wqy-zenhei && rm -rf /var/lib/apt/lists/*
+
+COPY pom.xml /app/
+COPY src /app/src/
+
+ENV MAVEN_CONFIG=/app/.m2
+WORKDIR /app
+RUN mvn package
+
+########################################################################################
+
 FROM tomcat:9
 MAINTAINER D.Ducatel
 
@@ -6,4 +19,4 @@ RUN apt-get update && \
     rm -rf /var/lib/apt/lists/*
 
 RUN rm -rf /usr/local/tomcat/webapps/ROOT
-ADD target/plantuml.war /usr/local/tomcat/webapps/ROOT.war
+COPY --from=builder /app/target/plantuml.war /usr/local/tomcat/webapps/ROOT.war


### PR DESCRIPTION
Hi,

Some new improvement about docker:

* Upgrading build of jetty and tomcat docker image by using a multi stage build. (Don't require maven to build a theses docker image)
* Add build of docker `arm v8` image into travis-ci
* Simplify Travis build