### PR TITLE
Set compiler version for jsp servlet

### DIFF
--- a/src/main/webapp/WEB-INF/web.xml
+++ b/src/main/webapp/WEB-INF/web.xml
@@ -7,6 +7,18 @@
 		<param-name>org.eclipse.jetty.servlet.Default.welcomeServlets</param-name>
 		<param-value>exact</param-value>
 	</context-param>
+ 	<servlet>
+    		<servlet-name>jsp</servlet-name>
+    		<servlet-class>org.apache.jasper.servlet.JspServlet</servlet-class>
+    		<init-param>
+	      		<param-name>compilerSourceVM</param-name>
+	      		<param-value>1.9</param-value>
+	    	</init-param>
+	    	<init-param>
+	      		<param-name>compilerTargetVM</param-name>
+      			<param-value>1.9</param-value>
+    		</init-param>
+  	</servlet>	
 	<servlet>
 		<servlet-name>plantumlservlet</servlet-name>
 		<servlet-class>net.sourceforge.plantuml.servlet.PlantUmlServlet</servlet-class>


### PR DESCRIPTION
Default is 1.5 and results in an error that 1.6 is required.