### PR TITLE
Dockerfile improvements for Jetty and Tomcat images

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+# .dockerignore -- stuff we don't need during image builds
+
+/.git/

--- a/Dockerfile.jetty
+++ b/Dockerfile.jetty
@@ -1,13 +1,8 @@
 FROM maven:3-jdk-8 AS builder
 
-RUN apt-get update && \
-    apt-get install -y --no-install-recommends graphviz fonts-wqy-zenhei && \
-    apt-get clean
-
 COPY pom.xml /app/
 COPY src /app/src/
 
-ENV MAVEN_CONFIG=/app/.m2
 WORKDIR /app
 RUN mvn package
 
@@ -25,5 +20,3 @@ RUN apt-get update && \
 USER jetty
 
 COPY --from=builder /app/target/plantuml.war /var/lib/jetty/webapps/ROOT.war
-
-

--- a/Dockerfile.jetty
+++ b/Dockerfile.jetty
@@ -19,4 +19,6 @@ RUN apt-get update && \
 
 USER jetty
 
+ENV GRAPHVIZ_DOT=/usr/bin/dot
+
 COPY --from=builder /app/target/plantuml.war /var/lib/jetty/webapps/ROOT.war

--- a/Dockerfile.jetty
+++ b/Dockerfile.jetty
@@ -4,7 +4,7 @@ COPY pom.xml /app/
 COPY src /app/src/
 
 WORKDIR /app
-RUN mvn package
+RUN mvn --batch-mode package
 
 ########################################################################################
 

--- a/Dockerfile.jetty
+++ b/Dockerfile.jetty
@@ -4,7 +4,7 @@ COPY pom.xml /app/
 COPY src /app/src/
 
 WORKDIR /app
-RUN mvn --batch-mode package
+RUN mvn --batch-mode --define java.net.useSystemProxies=true package
 
 ########################################################################################
 

--- a/Dockerfile.jetty
+++ b/Dockerfile.jetty
@@ -21,4 +21,5 @@ USER jetty
 
 ENV GRAPHVIZ_DOT=/usr/bin/dot
 
-COPY --from=builder /app/target/plantuml.war /var/lib/jetty/webapps/ROOT.war
+ARG BASE_URL=plantuml
+COPY --from=builder /app/target/plantuml.war /var/lib/jetty/webapps/$BASE_URL.war

--- a/Dockerfile.tomcat
+++ b/Dockerfile.tomcat
@@ -1,13 +1,8 @@
 FROM maven:3-jdk-8 AS builder
 
-RUN apt-get update && \
-    apt-get install -y --no-install-recommends graphviz fonts-wqy-zenhei && \
-    apt-get clean
-
 COPY pom.xml /app/
 COPY src /app/src/
 
-ENV MAVEN_CONFIG=/app/.m2
 WORKDIR /app
 RUN mvn package
 

--- a/Dockerfile.tomcat
+++ b/Dockerfile.tomcat
@@ -4,7 +4,7 @@ COPY pom.xml /app/
 COPY src /app/src/
 
 WORKDIR /app
-RUN mvn package
+RUN mvn --batch-mode package
 
 ########################################################################################
 

--- a/Dockerfile.tomcat
+++ b/Dockerfile.tomcat
@@ -4,7 +4,7 @@ COPY pom.xml /app/
 COPY src /app/src/
 
 WORKDIR /app
-RUN mvn --batch-mode package
+RUN mvn --batch-mode --define java.net.useSystemProxies=true package
 
 ########################################################################################
 

--- a/Dockerfile.tomcat
+++ b/Dockerfile.tomcat
@@ -15,5 +15,7 @@ RUN apt-get update && \
     apt-get install -y --no-install-recommends graphviz fonts-wqy-zenhei && \
     apt-get clean
 
+ENV GRAPHVIZ_DOT=/usr/bin/dot
+
 RUN rm -rf /usr/local/tomcat/webapps/ROOT
 COPY --from=builder /app/target/plantuml.war /usr/local/tomcat/webapps/ROOT.war

--- a/Dockerfile.tomcat
+++ b/Dockerfile.tomcat
@@ -17,5 +17,6 @@ RUN apt-get update && \
 
 ENV GRAPHVIZ_DOT=/usr/bin/dot
 
-RUN rm -rf /usr/local/tomcat/webapps/ROOT
-COPY --from=builder /app/target/plantuml.war /usr/local/tomcat/webapps/ROOT.war
+ARG BASE_URL=plantuml
+RUN rm -rf /usr/local/tomcat/webapps/$BASE_URL
+COPY --from=builder /app/target/plantuml.war /usr/local/tomcat/webapps/$BASE_URL.war


### PR DESCRIPTION
Having a go at building my own images behind a proxy at the office, I've backported the salient bits in the hope this helps.

Build results have been lightly tested locally on the default page, `http://localhost:8080/plantuml`, and by adding a `frame` construct.  This has been done for both the Jetty and the Tomcat variants.