### PR TITLE
Add Alpine Linux Dockerfile

### DIFF
--- a/Dockerfile.jetty
+++ b/Dockerfile.jetty
@@ -9,7 +9,7 @@ RUN mvn --batch-mode --define java.net.useSystemProxies=true package
 ########################################################################################
 
 FROM jetty
-MAINTAINER D.Ducatel
+LABEL maintainer D.Ducatel
 
 USER root
 

--- a/Dockerfile.jetty-alpine
+++ b/Dockerfile.jetty-alpine
@@ -1,0 +1,23 @@
+FROM maven:3-jdk-8-alpine AS builder
+
+COPY pom.xml /app/
+COPY src /app/src/
+
+WORKDIR /app
+RUN mvn --batch-mode --define java.net.useSystemProxies=true package
+
+########################################################################################
+
+FROM jetty:9-jre8-alpine
+LABEL maintainer D.Ducatel
+
+USER root
+
+RUN apk add --no-cache graphviz ttf-dejavu
+
+USER jetty
+
+ENV GRAPHVIZ_DOT=/usr/bin/dot
+
+ARG BASE_URL=ROOT
+COPY --from=builder /app/target/plantuml.war /var/lib/jetty/webapps/$BASE_URL.war

--- a/Dockerfile.tomcat
+++ b/Dockerfile.tomcat
@@ -9,7 +9,7 @@ RUN mvn --batch-mode --define java.net.useSystemProxies=true package
 ########################################################################################
 
 FROM tomcat:9
-MAINTAINER D.Ducatel
+LABEL MAINTAINER D.Ducatel
 
 RUN apt-get update && \
     apt-get install -y --no-install-recommends graphviz fonts-wqy-zenhei && \

--- a/Dockerfile.tomcat-alpine
+++ b/Dockerfile.tomcat-alpine
@@ -1,0 +1,21 @@
+FROM maven:3-jdk-8-alpine AS builder
+
+COPY pom.xml /app/
+COPY src /app/src/
+
+WORKDIR /app
+RUN mvn --batch-mode --define java.net.useSystemProxies=true package
+
+########################################################################################
+
+FROM tomcat:9-jre8-alpine
+LABEL MAINTAINER D.Ducatel
+
+RUN apk add --no-cache graphviz ttf-dejavu && \
+# Remove existing wars
+rm -r /usr/local/tomcat/webapps/*
+
+ENV GRAPHVIZ_DOT=/usr/bin/dot
+
+ARG BASE_URL=ROOT
+COPY --from=builder /app/target/plantuml.war /usr/local/tomcat/webapps/$BASE_URL.war

--- a/README.md
+++ b/README.md
@@ -38,8 +38,8 @@ How to run the server with Docker
 
 You can run Plantuml with jetty or tomcat container
 ```
-docker run -d -p 8080:8080 plantuml/plantuml-server:jetty
-docker run -d -p 8080:8080 plantuml/plantuml-server:tomcat
+docker run -d -p 8080:8080 --name plantuml-server plantuml/plantuml-server:jetty
+docker run -d -p 8080:8080 --name plantuml-server plantuml/plantuml-server:tomcat
 ```
 
 The server is now listing to [http://localhost:8080](http://localhost:8080).


### PR DESCRIPTION
Made Dockerfiles using Alpine Linux.
It reduces several disk space.

```console
$ docker images | grep plantuml
plantuml/plantuml-server                   jetty               e3d1bc847abd        4 weeks ago          512MB
plantuml/plantuml-server                   jetty-alpine        16b4da1348ea        About a minute ago   137MB
plantuml/plantuml-server                   tomcat              4df75ac78ecf        4 weeks ago          717MB
plantuml/plantuml-server                   tomcat-alpine       d9dac198c29f        About a minute ago   153MB
```

Used #77, thanks.

----

I hope you'll release docker tags like
- `plantuml/plantuml-server:jetty-alpine`
- `plantuml/plantuml-server:tomcat-alpine`