### PR TITLE
Refactor apt-get clean up in Dockerfile.{jetty,tomcat}

### DIFF
--- a/Dockerfile.jetty
+++ b/Dockerfile.jetty
@@ -15,7 +15,7 @@ USER root
 
 RUN apt-get update && \
     apt-get install -y --no-install-recommends graphviz fonts-noto-cjk && \
-    apt-get clean && rm -rf /var/lib/apt/lists/*
+    rm -rf /var/lib/apt/lists/*
 
 USER jetty
 

--- a/Dockerfile.tomcat
+++ b/Dockerfile.tomcat
@@ -28,7 +28,7 @@ MAINTAINER D.Ducatel
 
 RUN apt-get update && \
     apt-get install -y --no-install-recommends fonts-noto-cjk libexpat1 libcairo2 libpango1.0 libpangoft2-1.0 libpangocairo-1.0 && \
-    apt-get clean && rm -rf /var/lib/apt/lists/*
+    rm -rf /var/lib/apt/lists/*
 
 ENV GRAPHVIZ_DOT=/usr/bin/dot
 


### PR DESCRIPTION
Remove `apt-get clean` and manually clean up `/var/lib/apt/lists`

Ref:
https://docs.docker.com/develop/develop-images/dockerfile_best-practices/

> In addition, when you clean up the apt cache by removing
> /var/lib/apt/lists it reduces the image size, since the apt cache is not
> stored in a layer.

> Official Debian and Ubuntu images automatically run apt-get clean,
> so explicit invocation is not required.