### PR TITLE
Limit after_success deplyment to plantuml/plantuml-server

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ services:
     - docker
 
 after_success:
-  - if [ "$TRAVIS_BRANCH" == "master" ]; then
+  - if [ "$TRAVIS_BRANCH" == "master" ] && [ "$TRAVIS_REPO_SLUG" == "plantuml/plantuml-server" ] ; then
     docker login  -u $DOCKER_LOGIN -p $DOCKER_PASSWORD
 
     docker build --pull -t plantuml/plantuml-server:jetty -f Dockerfile.jetty . ;

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,8 @@ services:
     - docker
 
 after_success:
-  - docker login  -u $DOCKER_LOGIN -p $DOCKER_PASSWORD
   - if [ "$TRAVIS_BRANCH" == "master" ]; then
+    docker login  -u $DOCKER_LOGIN -p $DOCKER_PASSWORD
 
     docker build --pull -t plantuml/plantuml-server:jetty -f Dockerfile.jetty . ;
     docker build --pull -t plantuml/plantuml-server:tomcat -f Dockerfile.tomcat . ;


### PR DESCRIPTION
Without this limitation, forked repository will also run the process,
but may not have the proper credential/identity in most cases.