### PR TITLE
revert builder's base image to based on OpenJDK8 (non-headless)

### DIFF
--- a/Dockerfile.jetty
+++ b/Dockerfile.jetty
@@ -1,4 +1,4 @@
-FROM maven:3.6-jdk-8-slim AS builderjetty
+FROM maven:3.6-jdk-8 AS builderjetty
 
 COPY pom.xml /app/
 COPY src /app/src/

--- a/Dockerfile.tomcat
+++ b/Dockerfile.tomcat
@@ -1,4 +1,4 @@
-FROM maven:3.6-jdk-8-slim AS buildertomcat
+FROM maven:3.6-jdk-8 AS buildertomcat
 
 COPY pom.xml /app/
 COPY src /app/src/


### PR DESCRIPTION
headless OpenJDK does not refer `http_proxy` environment variable, so build image inside proxy will fail.
resolves #98