### PR TITLE
New servlet to expose the language tokens of the PlantUML engine

### DIFF
--- a/src/main/java/net/sourceforge/plantuml/servlet/LanguageServlet.java
+++ b/src/main/java/net/sourceforge/plantuml/servlet/LanguageServlet.java
@@ -1,0 +1,54 @@
+/* ========================================================================
+ * PlantUML : a free UML diagram generator
+ * ========================================================================
+ *
+ * Project Info:  http://plantuml.sourceforge.net
+ *
+ * This file is part of PlantUML.
+ *
+ * PlantUML is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PlantUML distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301,
+ * USA.
+ */
+package net.sourceforge.plantuml.servlet;
+
+import net.sourceforge.plantuml.syntax.LanguageDescriptor;
+
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.io.PrintStream;
+
+/**
+ * Servlet used to inspect the language keywords of the running PlantUML server.
+ * Same as {@code java -jar plantuml.jar -language}
+ */
+public class LanguageServlet extends HttpServlet {
+
+    @Override
+    protected void doPost(HttpServletRequest request, HttpServletResponse response)
+            throws ServletException, IOException {
+        throw new ServletException(new UnsupportedOperationException("The Language servlet only handles GET requests"));
+    }
+
+    @Override
+    protected void doGet(HttpServletRequest request, HttpServletResponse response)
+            throws ServletException, IOException {
+        final PrintStream ps = new PrintStream(response.getOutputStream());
+        response.setContentType("text/text");
+        new LanguageDescriptor().print(ps);
+    }
+}

--- a/src/main/webapp/WEB-INF/web.xml
+++ b/src/main/webapp/WEB-INF/web.xml
@@ -67,7 +67,11 @@
         <servlet-name>checkservlet</servlet-name>
         <servlet-class>net.sourceforge.plantuml.servlet.CheckSyntaxServlet</servlet-class>
     </servlet>
-	<!-- Patterns of the servlet -->
+    <servlet>
+        <servlet-name>languageservlet</servlet-name>
+        <servlet-class>net.sourceforge.plantuml.servlet.LanguageServlet</servlet-class>
+    </servlet>
+    <!-- Patterns of the servlet -->
 	<servlet-mapping>
 		<servlet-name>plantumlservlet</servlet-name>
 		<url-pattern>/welcome</url-pattern>
@@ -128,6 +132,10 @@
 		<servlet-name>proxyservlet</servlet-name>
 		<url-pattern>/proxy</url-pattern>
 	</servlet-mapping>
+    <servlet-mapping>
+        <servlet-name>languageservlet</servlet-name>
+        <url-pattern>/language</url-pattern>
+    </servlet-mapping>
 	<error-page>
 		<exception-type>java.lang.Throwable</exception-type>
 		<location>/error.jsp</location>

--- a/src/test/java/net/sourceforge/plantuml/servlet/TestLanguage.java
+++ b/src/test/java/net/sourceforge/plantuml/servlet/TestLanguage.java
@@ -1,0 +1,23 @@
+package net.sourceforge.plantuml.servlet;
+
+import com.meterware.httpunit.GetMethodWebRequest;
+import com.meterware.httpunit.WebConversation;
+import com.meterware.httpunit.WebRequest;
+import com.meterware.httpunit.WebResponse;
+
+import java.io.IOException;
+
+public class TestLanguage extends WebappTestCase {
+
+    /**
+     * Tests that the language for the current PlantUML server can be obtained through HTTP
+     */
+    public void testRetrieveLanguage() throws IOException {
+        WebConversation conversation = new WebConversation();
+        WebRequest request = new GetMethodWebRequest(getServerUrl() + "/language");
+        WebResponse response = conversation.getResource(request);
+        String languageText = response.getText();
+        assertTrue("Language contains @startuml", languageText.indexOf("@startuml") > 0);
+    }
+
+}


### PR DESCRIPTION
Same as `java -jar plantum.jar -language`, a new servlet is added to
expose the tokens supported by the current version of the PlantUML engine.
Useful to support tools relying on a running PlantUML server to support
syntax highlight.

Note: I'm the maintainer of the Emacs [plantuml-mode](https://github.com/skuro/plantuml-mode/). This feature would make it easier to support using PlantUML server as a rendering engine without requiring the local JAR to be installed.