### PR TITLE
add a dockerfile for arm64v8 for jetty

### DIFF
--- a/Dockerfile.arm64v8.jetty
+++ b/Dockerfile.arm64v8.jetty
@@ -1,0 +1,25 @@
+FROM arm64v8/maven:3.6-jdk-8 AS builderjetty
+
+COPY pom.xml /app/
+COPY src /app/src/
+
+WORKDIR /app
+RUN mvn --batch-mode --define java.net.useSystemProxies=true package
+
+########################################################################################
+
+FROM jetty:9.4-jre8
+MAINTAINER D.Ducatel
+
+USER root
+
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends graphviz fonts-noto-cjk && \
+    apt-get clean && rm -rf /var/lib/apt/lists/*
+
+USER jetty
+
+ENV GRAPHVIZ_DOT=/usr/bin/dot
+
+ARG BASE_URL=ROOT
+COPY --from=builderjetty /app/target/plantuml.war /var/lib/jetty/webapps/$BASE_URL.war


### PR DESCRIPTION
pre-build docker image is pushed on dockerhub: breakersun/plantuml-server:latest
tested on Phicomm N1(S905D), works fine.
Hope this helps.