### PR TITLE
Tags the docker image if there is a git tag

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,6 +32,10 @@ jobs:
               - docker login  -u $DOCKER_LOGIN -p $DOCKER_PASSWORD
               - docker build --pull -t plantuml/plantuml-server:jetty -f Dockerfile.jetty .
               - docker tag plantuml/plantuml-server:jetty plantuml/plantuml-server:latest
+              - if [ -n "$TRAVIS_TAG" ]; then
+                  docker tag plantuml/plantuml-server:jetty plantuml/plantuml-server:$TRAVIS_TAG;
+                  docker push plantuml/plantuml-server:$TRAVIS_TAG;
+                fi
               - docker push plantuml/plantuml-server:jetty
               - docker push plantuml/plantuml-server:latest
         - stage: docker-push


### PR DESCRIPTION
This will tag the docker image if TRAVIS_TAG is defined

https://docs.travis-ci.com/user/environment-variables/

> : If the current build is for a git tag, this variable is set to the tag’s name.
