### PR TITLE
Version 1.2019.11

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -179,7 +179,7 @@
     <dependency>
       <groupId>net.sourceforge.plantuml</groupId>
       <artifactId>plantuml</artifactId>
-      <version>1.2019.10</version>
+      <version>1.2019.11</version>
     </dependency>
     <dependency>
       <groupId>javax.servlet</groupId>


### PR DESCRIPTION
Currently, the release commit d73b61a for `v1.2019.11` is not in the `master` branch and therefore not pushed as `latest` (Docker-)tag on [Dockerhub](https://hub.docker.com/r/plantuml/plantuml-server/tags) by Travis.

This pull request adds the commit to the master branch. (To prevent a merge commit, you can merge with the "Rebase and Merge" button.)