### PR TITLE
Fix CI to only release docker tags on master branch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ stages:
   - name: docker-tag
     if: (tag IS present) AND (branch = master) AND (type != pull_request)
   - name: docker-push
-    if: branch = master
+    if: (branch = master) AND (type != pull_request)
 
 jobs:
     include:

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ services:
 stages:
   - build
   - name: docker-tag
-    if: (tag IS present) AND (branch = master)
+    if: (tag IS present) AND (branch = master) AND (type != pull_request)
   - name: docker-push
     if: branch = master
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ services:
 stages:
   - build
   - name: docker-tag
-    if: tag IS present
+    if: (tag IS present) AND (branch = master)
   - name: docker-push
     if: branch = master
 


### PR DESCRIPTION
Prevents docker release tags that are not also commits on the master branch.

Also fixes the build error in pull request #119.