### PR TITLE
fixed error when running with OpenJDK 14

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,8 +21,8 @@
         <artifactId>maven-compiler-plugin</artifactId>
         <version>2.3.2</version>
         <configuration>
-          <source>1.6</source>
-          <target>1.6</target>
+          <source>1.7</source>
+          <target>1.7</target>
         </configuration>
       </plugin>
       <plugin>


### PR DESCRIPTION
fixed [ERROR] error: Source option 6 is no longer supported. Use 7 or later in OpenJDK 14