### PR TITLE
Fixes docker-tag and docker-push stages in travis-ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,17 +1,19 @@
 language: java
 
-sudo: required
-
 jdk:
     - openjdk8
 
 services:
     - docker
 
+dist: xenial
+
+os: linux
+
 stages:
   - build
   - name: docker-tag
-    if: (tag IS present) AND (branch = master) AND (type != pull_request)
+    if: (tag IS present) AND (type != pull_request)
   - name: docker-push
     if: (branch = master) AND (type != pull_request)
 
@@ -23,34 +25,28 @@ jobs:
           before_deploy: cp target/plantuml.war target/plantuml-${TRAVIS_BRANCH}.war
           deploy:
               provider: releases
-              api_key: "$GITHUB_TOKEN"
+              token: "$GITHUB_TOKEN"
               file: "target/plantuml-${TRAVIS_BRANCH}.war"
-              skip_cleanup: true
-              on:
-                  tags: true
+              cleanup: true
 
         - stage: docker-tag
-          name: jetty
+          name: jetty-tag
           script:
               - if [ -z "$TRAVIS_TAG" ]; then exit 0; fi
               - docker login  -u $DOCKER_LOGIN -p $DOCKER_PASSWORD
               - docker build --pull -t plantuml/plantuml-server:jetty-$TRAVIS_TAG -f Dockerfile.jetty .
               - docker push plantuml/plantuml-server:jetty-$TRAVIS_TAG
-          on:
-              tags: true
 
         - stage: docker-tag
-          name: tomcat
+          name: tomcat-tag
           script:
               - if [ -z "$TRAVIS_TAG" ]; then exit 0; fi
               - docker login  -u $DOCKER_LOGIN -p $DOCKER_PASSWORD
               - docker build --pull -t plantuml/plantuml-server:tomcat-$TRAVIS_TAG -f Dockerfile.tomcat .
               - docker push plantuml/plantuml-server:tomcat-$TRAVIS_TAG
-          on:
-              tags: true
 
         - stage: docker-push
-          name: jetty
+          name: jetty-push
           script:
               - docker login  -u $DOCKER_LOGIN -p $DOCKER_PASSWORD
               - docker build --pull -t plantuml/plantuml-server:jetty -f Dockerfile.jetty .
@@ -58,7 +54,7 @@ jobs:
               - docker push plantuml/plantuml-server:jetty
               - docker push plantuml/plantuml-server:latest
         - stage: docker-push
-          name: tomcat
+          name: tomcat-push
           script:
               - docker login  -u $DOCKER_LOGIN -p $DOCKER_PASSWORD
               - docker build --pull -t plantuml/plantuml-server:tomcat -f Dockerfile.tomcat .


### PR DESCRIPTION
* Sets dist/os to the defaults
* Does not check for branch is master and a tag since these will never be true
* Removes on: tags=true
* Removes deprecated: sudo: required
* Replaces deprecated `api_token` with `token`
* Replaces deprecated `skip_clenaup` with `cleanup`
* Uses unique names so travis doesn't warn