### PR TITLE
Adds tag for deploy artifacts

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,6 +28,8 @@ jobs:
               token: "$GITHUB_TOKEN"
               file: "target/plantuml-${TRAVIS_BRANCH}.war"
               cleanup: true
+              on:
+                  tags: true
 
         - stage: docker-tag
           name: jetty-tag


### PR DESCRIPTION
Resolves the error:

```
Skipping a deployment with the releases provider because this branch is not permitted: v1.2020.8
```

to tag lines were misplaced in an earlier version of the config https://travis-ci.org/github/plantuml/plantuml-server/jobs/673315085/config#rccb_plantuml-server:.travis.yml@448c8f614fffb944.49

but the one under the deploy: key should not have been removed in https://github.com/plantuml/plantuml-server/commit/51e0922eeaecb233670a7d50d4f9d96be9dd5cfa

