### PR TITLE
Skips cleanup for release assets

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,7 @@ jobs:
               provider: releases
               token: "$GITHUB_TOKEN"
               file: "target/plantuml-${TRAVIS_BRANCH}.war"
-              cleanup: true
+              skip_cleanup: true
               on:
                   tags: true
 


### PR DESCRIPTION
For https://github.com/plantuml/plantuml-server/issues/144 , this skips the cleanup so that the war asset can be published successfully to GitHub.

 