### PR TITLE
Update tomcat tag from 9.0-jre8-slim to 9.0-jdk8-openjdk-slim

### DIFF
--- a/Dockerfile.tomcat
+++ b/Dockerfile.tomcat
@@ -8,7 +8,7 @@ RUN mvn --batch-mode --define java.net.useSystemProxies=true package
 
 ########################################################################################
 
-FROM tomcat:9.0-jre8-slim
+FROM tomcat:9.0-jdk8-openjdk-slim
 MAINTAINER D.Ducatel
 
 RUN apt-get update && \


### PR DESCRIPTION
Update tomcat tag from `9.0-jre8-slim` to `9.0-jdk8-openjdk-slim`. The previous tag does not seem to be supported anymore and is not updated to the security release `9.0.36`.