### PR TITLE
Bump docker parent image versions to target Java 11

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM maven:3-jdk-8
+FROM maven:3-jdk-11
 
 RUN apt-get update && apt-get install -y --no-install-recommends graphviz fonts-wqy-zenhei && rm -rf /var/lib/apt/lists/*
 

--- a/Dockerfile.jetty
+++ b/Dockerfile.jetty
@@ -1,4 +1,4 @@
-FROM maven:3.6-jdk-8 AS builderjetty
+FROM maven:3-jdk-11 AS builderjetty
 
 COPY pom.xml /app/
 COPY src /app/src/
@@ -8,7 +8,7 @@ RUN mvn --batch-mode --define java.net.useSystemProxies=true package
 
 ########################################################################################
 
-FROM jetty:9.4-jre8
+FROM jetty:9.4-jre11
 MAINTAINER D.Ducatel
 
 USER root

--- a/Dockerfile.tomcat
+++ b/Dockerfile.tomcat
@@ -1,4 +1,4 @@
-FROM maven:3.6-jdk-8 AS buildertomcat
+FROM maven:3-jdk-11 AS buildertomcat
 
 COPY pom.xml /app/
 COPY src /app/src/
@@ -8,7 +8,7 @@ RUN mvn --batch-mode --define java.net.useSystemProxies=true package
 
 ########################################################################################
 
-FROM tomcat:9.0-jdk8-openjdk-slim
+FROM tomcat:9.0-jdk11-openjdk-slim
 MAINTAINER D.Ducatel
 
 RUN apt-get update && \


### PR DESCRIPTION
Bumps up the docker parent images to use Java 11 versions in order to support HTTP/2.

Related issue #154