### PR TITLE
Could org.sourceforge.plantuml:plantumlservlet:1-SNAPSHOT drop off redundant dependencies to loose weight? 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -236,21 +236,59 @@
     	<groupId>org.scilab.forge</groupId>
     	<artifactId>jlatexmath</artifactId>
     	<version>1.0.7</version>
-    </dependency>
-    <dependency>
-    	<groupId>org.scilab.forge</groupId>
-    	<artifactId>jlatexmath-font-greek</artifactId>
-    	<version>1.0.7</version>
-    </dependency>
-    <dependency>
-    	<groupId>org.scilab.forge</groupId>
-    	<artifactId>jlatexmath-font-cyrillic</artifactId>
-    	<version>1.0.7</version>
+	<exclusions>
+            <exclusion>
+                <groupId>org.scilab.forge</groupId>
+                <artifactId>jlatexmath-font-cyrillic</artifactId>
+            </exclusion>
+            <exclusion>
+                <groupId>org.scilab.forge</groupId>
+                <artifactId>jlatexmath-font-greek</artifactId>
+            </exclusion>
+        </exclusions>
     </dependency>
     <dependency>
         <groupId>org.apache.xmlgraphics</groupId>
 	<artifactId>batik-all</artifactId>
 	<version>1.12</version>
+	<exclusions>
+            <exclusion>
+                <groupId>org.apache.xmlgraphics</groupId>
+                <artifactId>batik-constants</artifactId>
+            </exclusion>
+            <exclusion>
+                <groupId>org.apache.xmlgraphics</groupId>
+                <artifactId>batik-squiggle</artifactId>
+            </exclusion>
+            <exclusion>
+                <groupId>org.apache.xmlgraphics</groupId>
+		<artifactId>batik-rasterizer</artifactId>
+            </exclusion>
+            <exclusion>
+                <groupId>org.apache.xmlgraphics</groupId>
+                <artifactId>batik-ttf2svg</artifactId>
+            </exclusion>
+            <exclusion>
+                <groupId>org.apache.xmlgraphics</groupId>
+                <artifactId>batik-squiggle-ext</artifactId>
+            </exclusion>
+            <exclusion>
+                <groupId>org.apache.xmlgraphics</groupId>
+                <artifactId>batik-rasterizer-ext</artifactId>
+            </exclusion>
+            <exclusion>
+                <groupId>org.apache.xmlgraphics</groupId>
+                <artifactId>batik-svgpp</artifactId>
+            </exclusion>
+            <exclusion>
+                <groupId>org.apache.xmlgraphics</groupId>
+                <artifactId>batik-ext</artifactId>
+            </exclusion>
+            <exclusion>
+                <groupId>xml-apis</groupId>
+                <artifactId>xml-apis</artifactId>
+            </exclusion>
+        </exclusions>
     </dependency>
   </dependencies>
 </project>


### PR DESCRIPTION
@arnaudroques Hi, I am a user of project **_org.sourceforge.plantuml:plantumlservlet:1-SNAPSHOT_**. I found that its pom file introduced **_65_** dependencies. However, among them, **_12_** libraries (**_18%_**) have not been used by your project (the redundant dependencies are listed below). Reduce these useless dependencies can help prevent conflicts between library versions. MeanWhile, it can minimize the total added size to projects. It can also help enable advanced scenarios for users of your package. 
This PR helps **_org.sourceforge.plantuml:plantumlservlet:1-SNAPSHOT_** lose weight :) I have tested the revised configuration in my local environment. It is safe to remove the unused libraries.

Best regards


## Redundant dependencies----
<pre><code>
org.apache.xmlgraphics:batik-constants:jar:1.12:compile
xml-apis:xml-apis:jar:1.4.01:compile
org.webjars:codemirror:jar:3.21:compile
org.scilab.forge:jlatexmath-font-greek:jar:1.0.7:compile
org.apache.xmlgraphics:batik-rasterizer:jar:1.12:compile
org.apache.xmlgraphics:batik-squiggle:jar:1.12:compile
org.apache.xmlgraphics:batik-rasterizer-ext:jar:1.12:compile
org.apache.xmlgraphics:batik-ttf2svg:jar:1.12:compile
org.apache.xmlgraphics:batik-squiggle-ext:jar:1.12:compile
org.scilab.forge:jlatexmath-font-cyrillic:jar:1.0.7:compile
org.apache.xmlgraphics:batik-ext:jar:1.12:compile
org.apache.xmlgraphics:batik-svgpp:jar:1.12:compile
</code></pre>