### PR TITLE
Draft: Use `hostpath` consistently.

### DIFF
--- a/src/main/webapp/error.jsp
+++ b/src/main/webapp/error.jsp
@@ -1,7 +1,12 @@
 <%@ page isErrorPage="true" contentType="text/html; charset=utf-8" pageEncoding="utf-8" session="false" %>
-<%
-String contextRoot = request.getContextPath();
-%>
+
+<c:set var="contextroot" value="${pageContext.request.contextPath}" />
+<c:if test="${(pageContext.request.scheme == 'http' && pageContext.request.serverPort != 80) ||
+        (pageContext.request.scheme == 'https' && pageContext.request.serverPort != 443) }">
+    <c:set var="port" value=":${pageContext.request.serverPort}" />
+</c:if>
+<c:set var="scheme" value="${(not empty header['x-forwarded-proto']) ? header['x-forwarded-proto'] : pageContext.request.scheme}" />
+<c:set var="hostpath" value="${scheme}://${pageContext.request.serverName}${port}${contextroot}" />
 
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml">
@@ -10,9 +15,9 @@ String contextRoot = request.getContextPath();
     <meta http-equiv="expires" content="0" />
     <meta http-equiv="pragma" content="no-cache" />
     <meta http-equiv="cache-control" content="no-cache, must-revalidate" />
-    <link rel="stylesheet" href="<%=contextRoot %>/plantuml.css" type="text/css"/>
-    <link rel="icon" href="<%=contextRoot %>/favicon.ico" type="image/x-icon"/> 
-    <link rel="shortcut icon" href="<%=contextRoot %>/favicon.ico" type="image/x-icon"/>
+    <link rel="stylesheet" href="${hostpath}/plantuml.css" type="text/css"/>
+    <link rel="icon" href="${hostpath}/favicon.ico" type="image/x-icon"/> 
+    <link rel="shortcut icon" href="${hostpath}/favicon.ico" type="image/x-icon"/>
     <title>PlantUMLServer Error</title>
 </head>
 <body>

--- a/src/main/webapp/index.jsp
+++ b/src/main/webapp/index.jsp
@@ -25,11 +25,11 @@
     <meta http-equiv="expires" content="0" />
     <meta http-equiv="pragma" content="no-cache" />
     <meta http-equiv="cache-control" content="no-cache, must-revalidate" />
-    <link rel="icon" href="${contextroot}/favicon.ico" type="image/x-icon"/> 
-    <link rel="shortcut icon" href="${contextroot}/favicon.ico" type="image/x-icon"/>
-    <link rel="stylesheet" href="${contextroot}/plantuml.css" />
-    <link rel="stylesheet" href="${contextroot}/webjars/codemirror/3.21/lib/codemirror.css" />
-    <script src="${contextroot}/webjars/codemirror/3.21/lib/codemirror.js"></script>
+    <link rel="icon" href="${hostpath}/favicon.ico" type="image/x-icon"/> 
+    <link rel="shortcut icon" href="${hostpath}/favicon.ico" type="image/x-icon"/>
+    <link rel="stylesheet" href="${hostpath}/plantuml.css" />
+    <link rel="stylesheet" href="${hostpath}/webjars/codemirror/3.21/lib/codemirror.css" />
+    <script src="${hostpath}/webjars/codemirror/3.21/lib/codemirror.js"></script>
     <!-- <script src="mode/plantuml.js"></script> -->
     <script>
         window.onload = function() {


### PR DESCRIPTION
This should only affects the web application.

### Problem
Sometimes `hostpath` and sometimes `contextRoot`.

### Solution
This PR changes completely to `hostpath`.

### Why should this be changed
This fixes some issues if someone uses a proxy with an specific content path which is not root.

This change enables the following setup:
```nginx
location /plantuml/ {
  proxy_set_header HOST $host/plantuml;
  proxy_set_header X-Forwarded-Host $host/plantuml;
  proxy_set_header X-Real-IP $remote_addr;
  proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
  proxy_pass http://plantuml-server:8080/;
}
```
```yaml
version: '3.3'
services:
  plantuml-server:
    image: plantuml/plantuml-server:jetty
    container_name: plantuml-server
    ports:
      - 8080:8080
```