### PR TITLE
Fix /generate-jetty-start.sh being removed during build

### DIFF
--- a/Dockerfile.jetty
+++ b/Dockerfile.jetty
@@ -15,7 +15,7 @@ USER root
 
 RUN apt-get update && \
     apt-get install -y --no-install-recommends graphviz fonts-noto-cjk && \
-    rm -rf /var/lib/apt/lists/* \
+    rm -rf /var/lib/apt/lists/* && \
     /generate-jetty-start.sh
 
 USER jetty


### PR DESCRIPTION
Hello,

The file '/generate-jetty-start.sh' is being removed rather than called during the Docker build. This caused the read-only file system to not work with the Jetty images. Also fix #179.

## Before:

```console
% docker build . -f Dockerfile.jetty -t plantuml-server --progress plain
...
#5 [stage-1 2/3] RUN apt-get update &&     apt-get install -y --no-install-recommends graphviz fonts-noto-cjk &&     rm -rf /var/lib/apt/lists/*     /generate-jetty-start.sh
...

% docker run --rm -it --read-only -v /tmp/jetty plantuml-server
/docker-entrypoint.sh: 98: /docker-entrypoint.sh: cannot create /var/lib/jetty/jetty.start: Read-only file system
```

## After:

```console
% docker build . -f Dockerfile.jetty -t plantuml-server  --progress plain
...

#5 [stage-1 2/3] RUN apt-get update &&     apt-get install -y --no-install-recommends graphviz fonts-noto-cjk &&     rm -rf /var/lib/apt/lists/* &&    /generate-jetty-start.sh
...
% docker run --rm -it --read-only -v /tmp/jetty plantuml-server
... works ...
```