### PR TITLE
Refactor GitHub action

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,84 +2,98 @@ name: Main
 on:
   push:
     tags:
-      - '*'
+      - "v*"
 
 jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
-      with:
-        fetch-depth: 0
-    - uses: actions/setup-java@v2
-      with:
-        distribution: 'adopt'
-        java-version: '8'
-        check-latest: true
-        cache: 'maven'
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-java@v2
+        with:
+          distribution: "adopt"
+          java-version: "8"
+          check-latest: true
+          cache: "maven"
 
-    - name: build with maven
-      run: mvn --batch-mode --define java.net.useSystemProxies=true package
+      - name: build with maven
+        run: mvn --batch-mode --define java.net.useSystemProxies=true package
 
-    - name: get tag name
-      id: version
-      run: echo ::set-output name=VERSION::${GITHUB_REF#refs/*/}
+      - name: get tag name
+        id: version
+        run: echo ::set-output name=VERSION::${GITHUB_REF#refs/*/}
 
-    - name: create renamed build
-      run: cp target/plantuml.war target/plantuml-${{ steps.version.outputs.VERSION }}.war
+      - name: create renamed build
+        run: cp target/plantuml.war target/plantuml-${{ steps.version.outputs.VERSION }}.war
 
-    - name: upload binaries to release
-      uses: svenstaro/upload-release-action@v2
-      with:
-        repo_token: ${{ secrets.GITHUB_TOKEN }}
-        file: target/plantuml-${{ steps.version.outputs.VERSION }}.war
-        asset_name: plantuml-${{ steps.version.outputs.VERSION }}.war
-        tag: ${{ github.ref }}
-        overwrite: true
+      - name: upload binaries to release
+        uses: svenstaro/upload-release-action@v2
+        with:
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          file: target/plantuml-${{ steps.version.outputs.VERSION }}.war
+          asset_name: plantuml-${{ steps.version.outputs.VERSION }}.war
+          tag: ${{ github.ref }}
+          overwrite: true
 
-    - name: Set up QEMU
-      uses: docker/setup-qemu-action@v1
+      - name: Docker tomcat meta
+        id: docker_meta_tomcat
+        uses: crazy-max/ghaction-docker-meta@v3
+        with:
+          flavor: |
+            latest=false
+            prefix=
+            suffix=
+          images: plantuml/plantuml-server
+          tags: |
+            type=semver,pattern=tomcat-{{raw}}
+            type=raw,value=tomcat
 
-    - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v1
+      - name: Docker jetty meta
+        id: docker_meta_jetty
+        uses: crazy-max/ghaction-docker-meta@v3
+        with:
+          flavor: |
+            latest=true
+            prefix=
+            suffix=
+          images: plantuml/plantuml-server
+          tags: |
+            type=semver,pattern={{raw}}
+            type=semver,pattern=jetty-{{raw}}
+            type=raw,value=jetty
 
-    - name: Login to DockerHub
-      uses: docker/login-action@v1
-      with:
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+
+      - name: Login to DockerHub
+        uses: docker/login-action@v1
+        with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-    - name: build docker tagged images - jetty
-      uses: docker/build-push-action@v2
-      with:
-        push: true
-        tags: ${{ secrets.DOCKERHUB_USERNAME }}/plantuml-server:jetty-${{ steps.version.outputs.VERSION }}
-        file: Dockerfile.jetty
+      - name: Build & push tomcat
+        id: docker_build_tomcat
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          file: ./Dockerfile.tomcat
+          platforms: linux/amd64
+          push: true
+          tags: ${{ steps.docker_meta_tomcat.outputs.tags }}
+          labels: ${{ steps.docker_meta_tomcat.outputs.labels }}
 
-    - name: build docker latest images - jetty
-      uses: docker/build-push-action@v2
-      with:
-        push: true
-        tags: ${{ secrets.DOCKERHUB_USERNAME }}/plantuml-server:jetty
-        file: Dockerfile.jetty
-
-    - name: build docker tagged images - tomcat
-      uses: docker/build-push-action@v2
-      with:
-        push: true
-        tags: ${{ secrets.DOCKERHUB_USERNAME }}/plantuml-server:tomcat-${{ steps.version.outputs.VERSION }}
-        file: Dockerfile.tomcat
-
-    - name: build docker latest images - tomcat
-      uses: docker/build-push-action@v2
-      with:
-        push: true
-        tags: ${{ secrets.DOCKERHUB_USERNAME }}/plantuml-server:tomcat
-        file: Dockerfile.tomcat
-
-    - name: build docker latest images - jetty as latest
-      uses: docker/build-push-action@v2
-      with:
-        push: true
-        tags: ${{ secrets.DOCKERHUB_USERNAME }}/plantuml-server:latest
-        file: Dockerfile.jetty
+      - name: Build & push jetty
+        id: docker_build_jetty
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          file: ./Dockerfile.jetty
+          platforms: linux/amd64
+          push: true
+          tags: ${{ steps.docker_meta_jetty.outputs.tags }}
+          labels: ${{ steps.docker_meta_jetty.outputs.labels }}


### PR DESCRIPTION
This refactoring serves the following purposes.

- Only build on `v*` tags
- Reduce the number of Docker builds required
- Support multiple registries, such as `ghcr.io`, with no additional builds