### PR TITLE
Update JUnit Test Classes and there dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -84,7 +84,7 @@
         <artifactId>maven-surefire-plugin</artifactId>
         <version>2.14.1</version>
         <configuration>
-          <skipTests>true</skipTests>
+          <skipTests>${skipTests}</skipTests>
         </configuration>
       </plugin>
       <plugin>
@@ -174,6 +174,7 @@
     <maven.build.timestamp.format>yyyyMMdd-HHmm
     </maven.build.timestamp.format>
     <timestamp>${maven.build.timestamp}</timestamp>
+    <skipTests>true</skipTests>
   </properties>
   <dependencies>
     <dependency>
@@ -192,11 +193,6 @@
       <version>3.21</version>
     </dependency>
     <dependency>
-      <groupId>HTTPClient</groupId>
-      <artifactId>HTTPClient</artifactId>
-      <version>0.3-3</version>
-    </dependency>
-    <dependency>
       <groupId>javax.servlet</groupId>
       <artifactId>servlet-api</artifactId>
       <version>2.5</version>
@@ -205,19 +201,13 @@
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
-      <version>4.13.1</version>
+      <version>4.13.2</version>
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>httpunit</groupId>
-      <artifactId>httpunit</artifactId>
-      <version>1.7</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>rhino</groupId>
-      <artifactId>js</artifactId>
-      <version>1.7R2</version>
+      <groupId>net.sourceforge.htmlunit</groupId>
+      <artifactId>htmlunit</artifactId>
+      <version>2.53.0</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/src/main/java/net/sourceforge/plantuml/servlet/ProxyServlet.java
+++ b/src/main/java/net/sourceforge/plantuml/servlet/ProxyServlet.java
@@ -76,6 +76,7 @@ public class ProxyServlet extends HttpServlet {
             srcUrl = new URL(source);
         } catch (MalformedURLException mue) {
             mue.printStackTrace();
+            response.setStatus(400);
             return;
         }
 

--- a/src/main/webapp/index.jsp
+++ b/src/main/webapp/index.jsp
@@ -33,7 +33,7 @@
     <!-- <script src="mode/plantuml.js"></script> -->
     <script>
         window.onload = function() {
-            var myCodeMirror = CodeMirror.fromTextArea(
+            document.myCodeMirror = CodeMirror.fromTextArea(
                 document.getElementById("text"), 
                 {lineNumbers: true}
             );

--- a/src/test/java/net/sourceforge/plantuml/servlet/TestAsciiArt.java
+++ b/src/test/java/net/sourceforge/plantuml/servlet/TestAsciiArt.java
@@ -1,25 +1,27 @@
 package net.sourceforge.plantuml.servlet;
 
-import com.meterware.httpunit.GetMethodWebRequest;
-import com.meterware.httpunit.WebConversation;
-import com.meterware.httpunit.WebRequest;
-import com.meterware.httpunit.WebResponse;
+import java.io.IOException;
+import java.net.URL;
+import java.net.URLConnection;
+
 
 public class TestAsciiArt extends WebappTestCase {
 
     /**
      * Verifies the generation of the ascii art for the Bob -> Alice sample
      */
-    public void testSimpleSequenceDiagram() throws Exception {
-        WebConversation conversation = new WebConversation();
-        WebRequest request = new GetMethodWebRequest(getServerUrl() + "txt/" + TestUtils.SEQBOB);
-        WebResponse response = conversation.getResource(request);
+    public void testSimpleSequenceDiagram() throws IOException {
+        final URL url = new URL(getServerUrl() + "/txt/" + TestUtils.SEQBOB);
+        final URLConnection conn = url.openConnection();
         // Analyze response
         // Verifies the Content-Type header
-        assertEquals("Response content type is not TEXT PLAIN", "text/plain", response.getContentType());
-        assertEquals("Response character set is not UTF-8", "UTF-8", response.getCharacterSet());
+        assertEquals(
+            "Response content type is not TEXT PLAIN or UTF-8",
+            "text/plain;charset=utf-8",
+            conn.getContentType().toLowerCase()
+        );
         // Get the content and verify its size
-        String diagram = response.getText();
+        String diagram = getContentText(conn);
         int diagramLen = diagram.length();
         assertTrue(diagramLen > 200);
         assertTrue(diagramLen < 250);

--- a/src/test/java/net/sourceforge/plantuml/servlet/TestCharset.java
+++ b/src/test/java/net/sourceforge/plantuml/servlet/TestCharset.java
@@ -1,24 +1,27 @@
 package net.sourceforge.plantuml.servlet;
 
-import com.meterware.httpunit.GetMethodWebRequest;
-import com.meterware.httpunit.WebConversation;
-import com.meterware.httpunit.WebRequest;
-import com.meterware.httpunit.WebResponse;
+import java.io.IOException;
+import java.net.URL;
+import java.net.URLConnection;
+
 
 public class TestCharset extends WebappTestCase {
 
     /**
      * Verifies the preservation of unicode characters for the "Bob -> Alice : hell‽" sample
      */
-    public void testUnicodeSupport() throws Exception {
-        WebConversation conversation = new WebConversation();
-        WebRequest request = new GetMethodWebRequest(getServerUrl() + "txt/SyfFKj2rKt3CoKnELR1Io4ZDoNdKi1S0");
-        WebResponse response = conversation.getResource(request);
+    public void testUnicodeSupport() throws IOException {
+        final URL url = new URL(getServerUrl() + "/txt/SyfFKj2rKt3CoKnELR1Io4ZDoNdKi1S0");
+        final URLConnection conn = url.openConnection();
         // Analyze response
         // Verifies the Content-Type header
-        assertEquals("Response content type is not TEXT PLAIN", "text/plain", response.getContentType());
+        assertEquals(
+            "Response content type is not TEXT PLAIN or UTF-8",
+            "text/plain;charset=utf-8",
+            conn.getContentType().toLowerCase()
+        );
         // Get the content and verify that the interrobang unicode character is present
-        String diagram = response.getText();
+        String diagram = getContentText(conn);
         assertTrue("Interrobang unicode character is not preserved", diagram.contains("‽"));
     }
 
@@ -26,18 +29,22 @@ public class TestCharset extends WebappTestCase {
      * Verifies the preservation of unicode characters for the
      * "participant Bob [[http://www.snow.com/❄]]\nBob -> Alice" sample
      */
-    public void testUnicodeInCMap() throws Exception {
-        WebConversation conversation = new WebConversation();
-        WebRequest request = new GetMethodWebRequest(getServerUrl()
-                + "map/AqWiAibCpYn8p2jHSCfFKeYEpYWfAR3IroylBzShpiilrqlEpzL_DBSbDfOB9Azhf-2OavcS2W00");
-        WebResponse response = conversation.getResource(request);
+    public void testUnicodeInCMap() throws IOException {
+        final URL url = new URL(
+            getServerUrl() +
+            "/map/AqWiAibCpYn8p2jHSCfFKeYEpYWfAR3IroylBzShpiilrqlEpzL_DBSbDfOB9Azhf-2OavcS2W00"
+        );
+        final URLConnection conn = url.openConnection();
         // Analyze response
         // Verifies the Content-Type header
-        assertEquals("Response content type is not TEXT PLAIN", "text/plain", response.getContentType());
+        assertEquals(
+            "Response content type is not TEXT PLAIN or UTF-8",
+            "text/plain;charset=utf-8",
+            conn.getContentType().toLowerCase()
+        );
         // Get the content and verify that the snow unicode character is present
-        String map = response.getText();
+        String map = getContentText(conn);
         assertTrue("Snow unicode character is not preserved", map.contains("❄"));
     }
-
 
 }

--- a/src/test/java/net/sourceforge/plantuml/servlet/TestCheck.java
+++ b/src/test/java/net/sourceforge/plantuml/servlet/TestCheck.java
@@ -1,28 +1,32 @@
 package net.sourceforge.plantuml.servlet;
 
-import com.meterware.httpunit.GetMethodWebRequest;
-import com.meterware.httpunit.WebConversation;
-import com.meterware.httpunit.WebRequest;
-import com.meterware.httpunit.WebResponse;
+import java.io.IOException;
+import java.net.URL;
+import java.net.URLConnection;
+
 
 public class TestCheck extends WebappTestCase {
+
     /**
      * Verifies the generation of a syntax check for the following sample:
      * Bob -> Alice : hello
      */
-    public void testCorrectSequenceDiagram() throws Exception {
-        WebConversation conversation = new WebConversation();
-        WebRequest request = new GetMethodWebRequest(getServerUrl()
-            + "check/" + TestUtils.SEQBOB);
-        WebResponse response = conversation.getResource(request);
+    public void testCorrectSequenceDiagram() throws IOException {
+        final URL url = new URL(getServerUrl() + "/check/" + TestUtils.SEQBOB);
+        final URLConnection conn = url.openConnection();
         // Analyze response
         // Verifies the Content-Type header
-        assertEquals("Response content type is not TEXT PLAIN", "text/plain", response.getContentType());
-        assertEquals("Response character set is not UTF-8", "UTF-8", response.getCharacterSet());
+        assertEquals(
+            "Response content type is not TEXT PLAIN or UTF-8",
+            "text/plain;charset=utf-8",
+            conn.getContentType().toLowerCase()
+        );
         // Get the content, check its first characters and verify its size
-        String checkResult = response.getText();
-        assertTrue("Response content is not starting with (2 participants)",
-                checkResult.startsWith("(2 participants)"));
+        String checkResult = getContentText(conn);
+        assertTrue(
+            "Response content is not starting with (2 participants)",
+            checkResult.startsWith("(2 participants)")
+        );
         int checkLen = checkResult.length();
         assertTrue(checkLen > 1);
         assertTrue(checkLen < 100);
@@ -32,12 +36,10 @@ public class TestCheck extends WebappTestCase {
      * Check the syntax of an invalid sequence diagram :
      * Bob -
      */
-    public void testWrongDiagramSyntax() throws Exception {
-        WebConversation conversation = new WebConversation();
-        WebRequest request = new GetMethodWebRequest(getServerUrl() + "check/SyfFKj050000");
-        WebResponse response = conversation.getResource(request);
+    public void testWrongDiagramSyntax() throws IOException {
+        final URL url = new URL(getServerUrl() + "/check/SyfFKj050000");
         // Analyze response
-        String checkResult = response.getText();
+        String checkResult = getContentText(url);
         assertTrue("Response is not an error", checkResult.startsWith("(Error)"));
     }
 

--- a/src/test/java/net/sourceforge/plantuml/servlet/TestEPS.java
+++ b/src/test/java/net/sourceforge/plantuml/servlet/TestEPS.java
@@ -1,27 +1,30 @@
 package net.sourceforge.plantuml.servlet;
 
-import com.meterware.httpunit.GetMethodWebRequest;
-import com.meterware.httpunit.WebConversation;
-import com.meterware.httpunit.WebRequest;
-import com.meterware.httpunit.WebResponse;
+import java.io.IOException;
+import java.net.URL;
+import java.net.URLConnection;
 
-import java.util.Scanner;
 
 public class TestEPS extends WebappTestCase {
+
     /**
      * Verifies the generation of the EPS for the Bob -> Alice sample
      */
-    public void testSimpleSequenceDiagram() throws Exception {
-        WebConversation conversation = new WebConversation();
-        WebRequest request = new GetMethodWebRequest(getServerUrl() + "eps/" + TestUtils.SEQBOB);
-        WebResponse response = conversation.getResource(request);
+    public void testSimpleSequenceDiagram() throws IOException {
+        final URL url = new URL(getServerUrl() + "/eps/" + TestUtils.SEQBOB);
+        final URLConnection conn = url.openConnection();
         // Analyze response
         // Verifies the Content-Type header
-        assertEquals("Response content type is not EPS", "application/postscript", response.getContentType());
+        assertEquals(
+            "Response content type is not EPS",
+            "application/postscript",
+            conn.getContentType().toLowerCase()
+        );
         // Get the content and verify its size
-        String diagram = response.getText();
+        String diagram = getContentText(conn);
         int diagramLen = diagram.length();
         assertTrue(diagramLen > 10000);
         assertTrue(diagramLen < 12000);
     }
+
 }

--- a/src/test/java/net/sourceforge/plantuml/servlet/TestImage.java
+++ b/src/test/java/net/sourceforge/plantuml/servlet/TestImage.java
@@ -1,84 +1,76 @@
 package net.sourceforge.plantuml.servlet;
 
-import java.io.ByteArrayOutputStream;
-import java.io.InputStream;
+import java.io.IOException;
+import java.net.URL;
+import java.net.URLConnection;
+import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.util.Date;
 import java.util.Locale;
 
-import com.meterware.httpunit.GetMethodWebRequest;
-import com.meterware.httpunit.WebConversation;
-import com.meterware.httpunit.WebRequest;
-import com.meterware.httpunit.WebResponse;
 
 public class TestImage extends WebappTestCase {
+
     /**
      * Verifies the generation of the version image from an encoded URL
      */
-    public void testVersionImage() throws Exception {
-        WebConversation conversation = new WebConversation();
-        WebRequest request = new GetMethodWebRequest(getServerUrl() + "png/" + TestUtils.VERSION);
-        WebResponse response = conversation.getResource(request);
+    public void testVersionImage() throws IOException {
+        final URL url = new URL(getServerUrl() + "/png/" + TestUtils.VERSION);
+        final URLConnection conn = url.openConnection();
         // Analyze response
         // Verifies the Content-Type header
-        assertEquals("Response content type is not PNG", "image/png", response.getContentType());
+        assertEquals(
+            "Response content type is not PNG",
+            "image/png",
+            conn.getContentType().toLowerCase()
+        );
         // Get the image and verify its size
-        InputStream responseStream = response.getInputStream();
-        ByteArrayOutputStream imageStream = new ByteArrayOutputStream();
-        byte[] buf = new byte[1024];
-        int n = 0;
-        while ((n = responseStream.read(buf)) != -1) {
-            imageStream.write(buf, 0, n);
-        }
-        imageStream.close();
-        byte[] inMemoryImage = imageStream.toByteArray();
+        byte[] inMemoryImage = getContentAsBytes(conn);
         int diagramLen = inMemoryImage.length;
         assertTrue(diagramLen > 10000);
         assertTrue(diagramLen < 20000);
-        responseStream.close();
     }
 
     /**
      * Verifies that the HTTP header of a diagram incites the browser to cache it.
      */
-    public void testDiagramHttpHeader() throws Exception {
-        WebConversation conversation = new WebConversation();
-        // Bob -> Alice : hello
-        WebRequest request = new GetMethodWebRequest(getServerUrl() + "png/" + TestUtils.SEQBOB);
-        WebResponse response = conversation.getResource(request);
+    public void testDiagramHttpHeader() throws IOException, ParseException {
+        final URL url = new URL(getServerUrl() + "/png/" + TestUtils.SEQBOB);
+        final URLConnection conn = url.openConnection();
         // Analyze response
         // Verifies the Content-Type header
-        assertEquals("Response content type is not PNG", "image/png", response.getContentType());
+        assertEquals(
+            "Response content type is not PNG",
+            "image/png",
+            conn.getContentType().toLowerCase()
+        );
         // Verifies the availability of the Expires entry in the response header
-        assertNotNull(response.getHeaderField("Expires"));
+        assertNotNull(conn.getHeaderField("Expires"));
         // Verifies the availability of the Last-Modified entry in the response header
-        assertNotNull(response.getHeaderField("Last-Modified"));
+        assertNotNull(conn.getHeaderField("Last-Modified"));
         // Verifies the Last-Modified value is in the past
         SimpleDateFormat format = new SimpleDateFormat("EEE, dd MMM yyyy HH:mm:ss ZZZ", Locale.ENGLISH);
-        Date lastModified = format.parse(response.getHeaderField("Last-Modified"));
+        Date lastModified = format.parse(conn.getHeaderField("Last-Modified"));
         assertTrue("Last-Modified is not in the past", lastModified.before(new Date()));
-        // Consume the response
-        InputStream responseStream = response.getInputStream();
-        while (responseStream.read() != -1) {
-            // Do nothing
-        }
+        // Consume the response but do nothing with it
+        getContentAsBytes(conn);
     }
 
     /**
      * Verifies that the HTTP header of a diagram incites the browser to cache it.
      */
-    public void testOldImgURL() throws Exception {
-        WebConversation conversation = new WebConversation();
-        // Bob -> Alice : hello
-        WebRequest request = new GetMethodWebRequest(getServerUrl() + "img/" + TestUtils.SEQBOB);
-        WebResponse response = conversation.getResource(request);
+    public void testOldImgURL() throws IOException {
+        final URL url = new URL(getServerUrl() + "/img/" + TestUtils.SEQBOB);
+        final URLConnection conn = url.openConnection();
         // Analyze response
         // Verifies the Content-Type header
-        assertEquals("Response content type is not PNG", "image/png", response.getContentType());
-        // Consume the response
-        InputStream responseStream = response.getInputStream();
-        while (responseStream.read() != -1) {
-            // Do nothing
-        }
+        assertEquals(
+            "Response content type is not PNG",
+            "image/png",
+            conn.getContentType().toLowerCase()
+        );
+        // Consume the response but do nothing with it
+        getContentAsBytes(conn);
     }
+
 }

--- a/src/test/java/net/sourceforge/plantuml/servlet/TestLanguage.java
+++ b/src/test/java/net/sourceforge/plantuml/servlet/TestLanguage.java
@@ -1,11 +1,8 @@
 package net.sourceforge.plantuml.servlet;
 
-import com.meterware.httpunit.GetMethodWebRequest;
-import com.meterware.httpunit.WebConversation;
-import com.meterware.httpunit.WebRequest;
-import com.meterware.httpunit.WebResponse;
-
 import java.io.IOException;
+import java.net.URL;
+
 
 public class TestLanguage extends WebappTestCase {
 
@@ -13,10 +10,8 @@ public class TestLanguage extends WebappTestCase {
      * Tests that the language for the current PlantUML server can be obtained through HTTP
      */
     public void testRetrieveLanguage() throws IOException {
-        WebConversation conversation = new WebConversation();
-        WebRequest request = new GetMethodWebRequest(getServerUrl() + "/language");
-        WebResponse response = conversation.getResource(request);
-        String languageText = response.getText();
+        final URL url = new URL(getServerUrl() + "/language");
+        String languageText = getContentText(url);
         assertTrue("Language contains @startuml", languageText.indexOf("@startuml") > 0);
     }
 

--- a/src/test/java/net/sourceforge/plantuml/servlet/TestMap.java
+++ b/src/test/java/net/sourceforge/plantuml/servlet/TestMap.java
@@ -1,29 +1,41 @@
 package net.sourceforge.plantuml.servlet;
 
-import com.meterware.httpunit.GetMethodWebRequest;
-import com.meterware.httpunit.WebConversation;
-import com.meterware.httpunit.WebRequest;
-import com.meterware.httpunit.WebResponse;
+import java.io.IOException;
+import java.net.URL;
+import java.net.URLConnection;
+
 
 public class TestMap extends WebappTestCase {
+
     /**
      * Verifies the generation of the MAP for the following sample:
      *
      * participant Bob [[http://www.yahoo.com]]
      * Bob -> Alice : [[http://www.google.com]] hello
      */
-    public void testSimpleSequenceDiagram() throws Exception {
-        WebConversation conversation = new WebConversation();
-        WebRequest request = new GetMethodWebRequest(getServerUrl()
-            + "map/AqWiAibCpYn8p2jHSCfFKeYEpYWfAR3IroylBzUhJCp8pzTBpi-DZUK2IUhQAJZcP2QdAbYXgalFpq_FIOKeLCX8pSd91m00");
-        WebResponse response = conversation.getResource(request);
+    public void testSimpleSequenceDiagram() throws IOException {
+        final URL url = new URL(
+            getServerUrl() +
+            "/map/AqWiAibCpYn8p2jHSCfFKeYEpYWfAR3IroylBzUhJCp8pzTBpi-DZUK2IUhQAJZcP2QdAbYXgalFpq_FIOKeLCX8pSd91m00"
+        );
+        final URLConnection conn = url.openConnection();
         // Analyze response
         // Verifies the Content-Type header
-        assertEquals("Response content type is not TEXT PLAIN", "text/plain", response.getContentType());
-        assertEquals("Response character set is not UTF-8", "UTF-8", response.getCharacterSet());
+        assertEquals(
+            "Response content type is not TEXT PLAIN or UTF-8",
+            "text/plain;charset=utf-8",
+            conn.getContentType().toLowerCase()
+        );
         // Get the content, check its first characters and verify its size
-        String diagram = response.getText();
-        assertTrue("Response content is not starting with <area", diagram.startsWith("<area"));
+        String diagram = getContentText(conn);
+        assertTrue(
+            "Response content is not starting with <map",
+            diagram.startsWith("<map")
+        );
+        assertTrue(
+            "Response content (2. line) is not starting with <area",
+            diagram.split("\\n", 2)[1].startsWith("<area")
+        );
         int diagramLen = diagram.length();
         assertTrue(diagramLen > 200);
         assertTrue(diagramLen < 300);
@@ -33,33 +45,43 @@ public class TestMap extends WebappTestCase {
      * Check the content of the MAP for the sequence diagram sample
      * Verify structure of the area tags
      */
-    public void testSequenceDiagramContent() throws Exception {
-        WebConversation conversation = new WebConversation();
-        WebRequest request = new GetMethodWebRequest(getServerUrl()
-            + "map/AqWiAibCpYn8p2jHSCfFKeYEpYWfAR3IroylBzUhJCp8pzTBpi-DZUK2IUhQAJZcP2QdAbYXgalFpq_FIOKeLCX8pSd91m00");
-        WebResponse response = conversation.getResource(request);
+    public void testSequenceDiagramContent() throws IOException {
+        final URL url = new URL(
+            getServerUrl() +
+            "/map/AqWiAibCpYn8p2jHSCfFKeYEpYWfAR3IroylBzUhJCp8pzTBpi-DZUK2IUhQAJZcP2QdAbYXgalFpq_FIOKeLCX8pSd91m00"
+        );
         // Analyze response
         // Get the data contained in the XML
-        String map = response.getText();
-        assertTrue("Response is not a list of tags", map.matches("(<([^<>]+)>)+"));
-        assertTrue("Response doesn't contain the area structure",
-                map.matches(".*(area shape=\".+\" id=\".+\" href=\".+\").*"));
+        String map = getContentText(url);
+        // Verify shape:
+        // <map id="..." name="...">
+        // <area shape="..." id="..." href="..." ... />
+        // <area shape="..." id="..." href="..." ... />
+        // </map>
+        assertTrue(
+            "Response doesn't match shape",
+            map.matches("^<map id=\".+\" name=\".+\">\n(<area shape=\".+\" id=\".+\" href=\".+\".*/>\n){2}</map>\n*$")
+        );
     }
 
     /**
      * Check the empty MAP of a sequence diagram without link
      * This test uses the simple Bob -> Alice
      */
-    public void testSequenceDiagramWithoutLink() throws Exception {
-        WebConversation conversation = new WebConversation();
-        WebRequest request = new GetMethodWebRequest(getServerUrl() + "map/" + TestUtils.SEQBOB);
-        WebResponse response = conversation.getResource(request);
+    public void testSequenceDiagramWithoutLink() throws IOException {
+        final URL url = new URL(getServerUrl() + "/map/" + TestUtils.SEQBOB);
+        final URLConnection conn = url.openConnection();
         // Analyze response
         // Verifies the Content-Type header
-        assertEquals("Response content type is not TEXT PLAIN", "text/plain", response.getContentType());
-        // Get the content, check it's an empty response
-        String diagram = response.getText();
+        assertEquals(
+            "Response content type is not TEXT PLAIN or UTF-8",
+            "text/plain;charset=utf-8",
+            conn.getContentType().toLowerCase()
+        );
+        // Get the data contained in the XML
+        String diagram = getContentText(conn);
         int diagramLen = diagram.length();
         assertEquals(0, diagramLen);
     }
+
 }

--- a/src/test/java/net/sourceforge/plantuml/servlet/TestOldProxy.java
+++ b/src/test/java/net/sourceforge/plantuml/servlet/TestOldProxy.java
@@ -1,52 +1,45 @@
 package net.sourceforge.plantuml.servlet;
 
-import java.io.ByteArrayOutputStream;
-import java.io.InputStream;
+import java.io.IOException;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.net.URLConnection;
 
-import com.meterware.httpunit.GetMethodWebRequest;
-import com.meterware.httpunit.WebConversation;
-import com.meterware.httpunit.WebForm;
-import com.meterware.httpunit.WebRequest;
-import com.meterware.httpunit.WebResponse;
 
 public class TestOldProxy extends WebappTestCase {
+
     /**
      * Verifies the proxified reception of the default Bob and Alice diagram
      */
-    public void testDefaultProxy() throws Exception {
-        WebConversation conversation = new WebConversation();
-        WebRequest request = new GetMethodWebRequest(getServerUrl() + "proxy/" + getServerUrl()
-                + "resource/test2diagrams.txt");
-        WebResponse response = conversation.getResource(request);
+    public void testDefaultProxy() throws IOException {
+        final URL url = new URL(getServerUrl() + "/proxy/" + getServerUrl() + "/resource/test2diagrams.txt");
+        final URLConnection conn = url.openConnection();
         // Analyze response
         // Verifies the Content-Type header
-        // assertEquals( "Response content type is not PNG", "image/png", response.getContentType());
+        assertEquals(
+            "Response content type is not PNG",
+            "image/png",
+            conn.getContentType().toLowerCase()
+        );
         // Get the image and verify its size (~2000 bytes)
-        InputStream responseStream = response.getInputStream();
-        ByteArrayOutputStream imageStream = new ByteArrayOutputStream();
-        byte[] buf = new byte[1024];
-        int n = 0;
-        while ((n = responseStream.read(buf)) != -1) {
-            imageStream.write(buf, 0, n);
-        }
-        imageStream.close();
-        responseStream.close();
-        byte[] inMemoryImage = imageStream.toByteArray();
+        byte[] inMemoryImage = getContentAsBytes(conn);
         int diagramLen = inMemoryImage.length;
-        assertTrue(diagramLen > 1500);
-        assertTrue(diagramLen < 2500);
+        assertTrue(diagramLen > 2000);
+        assertTrue(diagramLen < 3000);
     }
 
-    public void testProxyWithFormat() throws Exception {
-        WebConversation conversation = new WebConversation();
-        WebRequest request = new GetMethodWebRequest(getServerUrl() + "proxy/svg/" + getServerUrl()
-                + "resource/test2diagrams.txt");
-        WebResponse response = conversation.getResource(request);
+    public void testProxyWithFormat() throws IOException {
+        final URL url = new URL(getServerUrl() + "/proxy/svg/" + getServerUrl() + "/resource/test2diagrams.txt");
+        final URLConnection conn = url.openConnection();
         // Analyze response
         // Verifies the Content-Type header
-        // TODO assertEquals( "Response content type is not SVG", "image/svg+xml", response.getContentType());
+        assertEquals(
+            "Response content type is not SVG",
+            "image/svg+xml",
+            conn.getContentType().toLowerCase()
+        );
         // Get the content and verify its size
-        String diagram = response.getText();
+        String diagram = getContentText(conn);
         int diagramLen = diagram.length();
         assertTrue(diagramLen > 1000);
         assertTrue(diagramLen < 3000);
@@ -55,15 +48,22 @@ public class TestOldProxy extends WebappTestCase {
     /**
      * Verifies that the HTTP header of a diagram incites the browser to cache it.
      */
-    public void testInvalidUrl() throws Exception {
-        WebConversation conversation = new WebConversation();
-        // Try to proxify an invalid address
-        WebRequest request = new GetMethodWebRequest(getServerUrl() + "proxy/invalidURL");
-        WebResponse response = conversation.getResource(request);
-        // Analyze response, it must be the empty form
-        // Verifies the Content-Type header
-        assertEquals("Response content type is not HTML", "text/html", response.getContentType());
-        WebForm[] forms = response.getForms();
-        assertEquals(2, forms.length);
+    public void testInvalidUrl() throws IOException {
+        final URL url = new URL(getServerUrl() + "/proxy/invalidURL");
+        final HttpURLConnection conn = (HttpURLConnection)url.openConnection();
+        // Analyze response
+        // Get the content and verify its size
+        assertEquals(
+            "Response is not empty",
+            0,
+            conn.getContentLength()
+        );
+        // Check if status code is 400
+        assertEquals(
+            "Bad HTTP status received",
+            400,
+            conn.getResponseCode()
+        );
     }
+
 }

--- a/src/test/java/net/sourceforge/plantuml/servlet/TestProxy.java
+++ b/src/test/java/net/sourceforge/plantuml/servlet/TestProxy.java
@@ -1,65 +1,105 @@
 package net.sourceforge.plantuml.servlet;
 
-import java.io.ByteArrayOutputStream;
-import java.io.InputStream;
+import java.io.IOException;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.net.URLConnection;
 
-import com.meterware.httpunit.GetMethodWebRequest;
-import com.meterware.httpunit.WebConversation;
-import com.meterware.httpunit.WebRequest;
-import com.meterware.httpunit.WebResponse;
 
 public class TestProxy extends WebappTestCase {
+
     /**
      * Verifies the proxified reception of the default Bob and Alice diagram
      */
-    public void testDefaultProxy() throws Exception {
-        WebConversation conversation = new WebConversation();
-        WebRequest request = new GetMethodWebRequest(getServerUrl()
-            + "proxy?src=" + getServerUrl() + "resource/test2diagrams.txt");
-        WebResponse response = conversation.getResource(request);
+    public void testDefaultProxy() throws IOException {
+        final URL url = new URL(getServerUrl() + "/proxy?src=" + getServerUrl() + "/resource/test2diagrams.txt");
+        final URLConnection conn = url.openConnection();
         // Analyze response
         // Verifies the Content-Type header
-        assertEquals("Response content type is not PNG", "image/png", response.getContentType());
+        assertEquals(
+            "Response content type is not PNG",
+            "image/png",
+            conn.getContentType().toLowerCase()
+        );
         // Get the image and verify its size (~2000 bytes)
-        InputStream responseStream = response.getInputStream();
-        ByteArrayOutputStream imageStream = new ByteArrayOutputStream();
-        byte[] buf = new byte[1024];
-        int n = 0;
-        while ((n = responseStream.read(buf)) != -1) {
-            imageStream.write(buf, 0, n);
-        }
-        imageStream.close();
-        responseStream.close();
-        byte[] inMemoryImage = imageStream.toByteArray();
+        byte[] inMemoryImage = getContentAsBytes(conn);
         int diagramLen = inMemoryImage.length;
-        assertTrue(diagramLen > 1500);
-        assertTrue(diagramLen < 2500);
+        assertTrue(diagramLen > 2000);
+        assertTrue(diagramLen < 3000);
     }
-/*
-    public void testProxyWithFormat() throws Exception {
-        WebConversation conversation = new WebConversation();
-        WebRequest request = new GetMethodWebRequest(getServerUrl()
-            + "proxy?format=svg&src=" + getServerUrl() + "resource/test2diagrams.txt");
-        WebResponse response = conversation.getResource(request);
+
+    /**
+     * Verifies the proxified reception of the default Bob and Alice diagram with defined format.
+     */
+    public void testProxyWithFormat() throws IOException {
+        final URL url = new URL(getServerUrl() + "/proxy?fmt=svg&src=" + getServerUrl() + "/resource/test2diagrams.txt");
+        final URLConnection conn = url.openConnection();
         // Analyze response
         // Verifies the Content-Type header
-        assertEquals( "Response content type is not SVG", "image/svg+xml", response.getContentType());
+        assertEquals(
+            "Response content type is not SVG",
+            "image/svg+xml",
+            conn.getContentType().toLowerCase()
+        );
         // Get the content and verify its size
-        String diagram = response.getText();
+        String diagram = getContentText(conn);
         int diagramLen = diagram.length();
-        assertTrue(diagramLen > 1000);
+        assertTrue(diagramLen > 2000);
         assertTrue(diagramLen < 3000);
+    }
+
+    /**
+     * Verifies the proxified reception of the default Bob and Alice diagram with defined format and format (idx=0).
+     */
+    public void testProxyWithFormatIdx0() throws IOException {
+        final URL url = new URL(getServerUrl() + "/proxy?fmt=svg&idx=0&src=" + getServerUrl() + "/resource/test2diagrams.txt");
+        final URLConnection conn = url.openConnection();
+        // Analyze response
+        // Verifies the Content-Type header
+        assertEquals(
+            "Response content type is not SVG",
+            "image/svg+xml",
+            conn.getContentType().toLowerCase()
+        );
+        // Get the content and verify its size
+        String diagram = getContentText(conn);
+        int diagramLen = diagram.length();
+        assertTrue(diagramLen > 2000);
+        assertTrue(diagramLen < 3000);
+    }
+
+    /**
+     * Verifies the proxified reception of the default Bob and Alice diagram with defined format and format (idx=1).
+     */
+    public void testProxyWithFormatIdx1() throws IOException {
+        final URL url = new URL(getServerUrl() + "/proxy?fmt=svg&idx=1&src=" + getServerUrl() + "/resource/test2diagrams.txt");
+        final URLConnection conn = url.openConnection();
+        // Analyze response
+        // Verifies the Content-Type header
+        assertEquals(
+            "Response content type is not SVG",
+            "image/svg+xml",
+            conn.getContentType().toLowerCase()
+        );
+        // Get the content and verify its size
+        String diagram = getContentText(conn);
+        int diagramLen = diagram.length();
+        assertTrue(diagramLen > 5000);
+        assertTrue(diagramLen < 6000);
     }
 
     /**
      * Verifies that the HTTP header of a diagram incites the browser to cache it.
      */
-    public void testInvalidUrl() throws Exception {
-        WebConversation conversation = new WebConversation();
-        // Try to proxify an invalid address
-        WebRequest request = new GetMethodWebRequest(getServerUrl() + "proxy?src=invalidURL");
-        WebResponse response = conversation.getResource(request);
-        // Analyze response, it must be HTTP error 500
-        //assertEquals("Bad HTTP status received", 500, response.getResponseCode());
+    public void testInvalidUrl() throws IOException {
+        final URL url = new URL(getServerUrl() + "/proxy?src=invalidURL");
+        final HttpURLConnection conn = (HttpURLConnection)url.openConnection();
+        // Analyze response, it must be HTTP error 400
+        assertEquals(
+            "Bad HTTP status received",
+            400,
+            conn.getResponseCode()
+        );
     }
+
 }

--- a/src/test/java/net/sourceforge/plantuml/servlet/TestUtils.java
+++ b/src/test/java/net/sourceforge/plantuml/servlet/TestUtils.java
@@ -4,7 +4,7 @@ package net.sourceforge.plantuml.servlet;
 /**
  * Utility class for the unit tests
  */
-public class TestUtils {
+public abstract class TestUtils {
 
     /*
      * Theses strings are the compressed form of a PlantUML diagram.
@@ -20,8 +20,4 @@ public class TestUtils {
      */
     public static final String SEQBOB = "SyfFKj2rKt3CoKnELR1Io4ZDoSa70000";
 
-    protected TestUtils() {
-        // prevents calls from subclass
-        throw new UnsupportedOperationException();
-    }
 }

--- a/src/test/java/net/sourceforge/plantuml/servlet/WebappTestCase.java
+++ b/src/test/java/net/sourceforge/plantuml/servlet/WebappTestCase.java
@@ -1,22 +1,47 @@
 package net.sourceforge.plantuml.servlet;
 
+import java.io.BufferedReader;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.net.URL;
+import java.net.URLConnection;
+
 import junit.framework.TestCase;
+import net.sourceforge.plantuml.servlet.server.EmbeddedJettyServer;
+import net.sourceforge.plantuml.servlet.server.ExternalServer;
+import net.sourceforge.plantuml.servlet.server.ServerUtils;
+
 
 public abstract class WebappTestCase extends TestCase {
 
-    private ServerUtils serverUtils;
+    private final ServerUtils serverUtils;
 
     public WebappTestCase() {
-        super();
+        this(null);
     }
 
     public WebappTestCase(String name) {
         super(name);
+
+        String uri = System.getProperty("system.test.server", "");
+        //uri = "http://localhost:8080/plantuml";
+        if (!uri.isEmpty()) {
+            // mvn test -DskipTests=false -DargLine="-Dsystem.test.server=http://localhost:8080/plantuml"
+            System.out.println("Test against external server: " + uri);
+            serverUtils = new ExternalServer(uri);
+            return;
+        }
+
+        // mvn test -DskipTests=false
+        System.out.println("Test against embedded jetty server.");
+        serverUtils = new EmbeddedJettyServer();
     }
 
     @Override
     public void setUp() throws Exception {
-        serverUtils = new ServerUtils(true);
+        serverUtils.startServer();
     }
 
     @Override
@@ -26,6 +51,56 @@ public abstract class WebappTestCase extends TestCase {
 
     protected String getServerUrl() {
         return serverUtils.getServerUrl();
+    }
+
+    public String getContentText(final URL url) throws IOException {
+        try (final InputStream responseStream = url.openStream()) {
+            return getContentText(responseStream);
+        }
+    }
+
+    public String getContentText(final URLConnection conn) throws IOException {
+        try (final InputStream responseStream = conn.getInputStream()) {
+            return getContentText(responseStream);
+        }
+    }
+
+    public String getContentText(final InputStream stream) throws IOException {
+        try (
+            final InputStreamReader isr = new InputStreamReader(stream);
+            final BufferedReader br = new BufferedReader(isr);
+        ) {
+            String line;
+            StringBuffer sb = new StringBuffer();
+            while ((line = br.readLine()) != null) {
+                sb.append(line);
+                sb.append("\n");
+            }
+            return sb.toString().trim();
+        }
+    }
+
+    public byte[] getContentAsBytes(final URL url) throws IOException {
+        try (final InputStream responseStream = url.openStream()) {
+            return getContentAsBytes(responseStream);
+        }
+    }
+
+    public byte[] getContentAsBytes(final URLConnection conn) throws IOException {
+        try (final InputStream responseStream = conn.getInputStream()) {
+            return getContentAsBytes(responseStream);
+        }
+    }
+
+    public byte[] getContentAsBytes(final InputStream stream) throws IOException {
+        try (final ByteArrayOutputStream byteStream = new ByteArrayOutputStream()) {
+            byte[] buf = new byte[1024];
+            int n = 0;
+            while ((n = stream.read(buf)) != -1) {
+                byteStream.write(buf, 0, n);
+            }
+            return byteStream.toByteArray();
+        }
     }
 
 }

--- a/src/test/java/net/sourceforge/plantuml/servlet/server/EmbeddedJettyServer.java
+++ b/src/test/java/net/sourceforge/plantuml/servlet/server/EmbeddedJettyServer.java
@@ -1,4 +1,4 @@
-package net.sourceforge.plantuml.servlet;
+package net.sourceforge.plantuml.servlet.server;
 
 import java.net.InetSocketAddress;
 
@@ -6,20 +6,14 @@ import org.eclipse.jetty.server.Connector;
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.webapp.WebAppContext;
 
-public class ServerUtils {
+
+public class EmbeddedJettyServer implements ServerUtils {
 
     private Server server;
 
-    public ServerUtils(boolean start) throws Exception {
+    public EmbeddedJettyServer() {
         server = new Server(new InetSocketAddress("127.0.0.1", 0));
         server.addBean(new WebAppContext(server, "src/main/webapp", "/plantuml"));
-        if (start) {
-            startServer();
-        }
-    }
-
-    public ServerUtils() throws Exception {
-        this(false);
     }
 
     public void startServer() throws Exception {
@@ -32,7 +26,7 @@ public class ServerUtils {
 
     public String getServerUrl() {
         Connector connector = server.getConnectors()[0];
-        return String.format("http://%s:%d/plantuml/", connector.getHost(), connector.getLocalPort());
+        return String.format("http://%s:%d/plantuml", connector.getHost(), connector.getLocalPort());
     }
 
 }

--- a/src/test/java/net/sourceforge/plantuml/servlet/server/ExternalServer.java
+++ b/src/test/java/net/sourceforge/plantuml/servlet/server/ExternalServer.java
@@ -1,0 +1,23 @@
+package net.sourceforge.plantuml.servlet.server;
+
+
+public class ExternalServer implements ServerUtils {
+
+    private final String uri;
+
+    public ExternalServer(String uri) {
+        this.uri = uri;
+    }
+
+    @Override
+    public void startServer() throws Exception { }
+
+    @Override
+    public void stopServer() throws Exception { }
+
+    @Override
+    public String getServerUrl() {
+        return this.uri;
+    }
+    
+}

--- a/src/test/java/net/sourceforge/plantuml/servlet/server/ServerUtils.java
+++ b/src/test/java/net/sourceforge/plantuml/servlet/server/ServerUtils.java
@@ -1,0 +1,12 @@
+package net.sourceforge.plantuml.servlet.server;
+
+
+public interface ServerUtils {
+
+    public void startServer() throws Exception;
+
+    public void stopServer() throws Exception;
+
+    public abstract String getServerUrl();
+
+}


### PR DESCRIPTION
This PR looks still very huge. However, this is due to the exchange of the test framework.
This PR is one part of #189.

### File changes summary

```
pom.xml                                                             |  22 +--
src/main/java/net/sourceforge/plantuml/servlet/OldProxyServlet.java |  68 +++----
src/main/java/net/sourceforge/plantuml/servlet/ProxyServlet.java    |   1 +
src/main/webapp/index.jsp                                           |   2 +-
src/test/java/net/sourceforge/plantuml/servlet/ServerUtils.java     |  38 ----
src/test/java/net/sourceforge/plantuml/servlet/TestAsciiArt.java    |  24 +--
src/test/java/net/sourceforge/plantuml/servlet/TestCharset.java     |  43 +++--
src/test/java/net/sourceforge/plantuml/servlet/TestCheck.java       |  40 ++--
src/test/java/net/sourceforge/plantuml/servlet/TestEPS.java         |  25 +--
src/test/java/net/sourceforge/plantuml/servlet/TestForm.java        | 294 ++++++++++++++++++------------
src/test/java/net/sourceforge/plantuml/servlet/TestImage.java       |  84 ++++-----
src/test/java/net/sourceforge/plantuml/servlet/TestLanguage.java    |  13 +-
src/test/java/net/sourceforge/plantuml/servlet/TestMap.java         |  80 +++++---
src/test/java/net/sourceforge/plantuml/servlet/TestOldProxy.java    |  84 ++++-----
src/test/java/net/sourceforge/plantuml/servlet/TestProxy.java       | 120 ++++++++----
src/test/java/net/sourceforge/plantuml/servlet/TestSVG.java         | 131 +++++++------
src/test/java/net/sourceforge/plantuml/servlet/TestUtils.java       |   6 +-
src/test/java/net/sourceforge/plantuml/servlet/WebappTestCase.java  |  81 +++++++-
18 files changed, 660 insertions(+), 496 deletions(-)
```

The first 4 files contain real changes.
The test files themselfe should not contain important changes (framework switch).


### Changes

- Test Server
  * It is now possible run the junit tests against an external plantuml-server.
    This could be used to also test the finished jetty und tomcat docker images.
    Note: `ServerUtils.java` moved to `server/EmbeddedJettyServer.java`
  * **Open TODO**: The embedded jetty server (before ServerUtils.java) uses jetty 8. Jetty 8 is deprecated and at least I have sometimes problems to get this version running on my system.
    Possible solutions
      - update to jetty 11
      - test against external server, e.g. `docker-compose up` (also see: WebappTestCase Constructor)
- JUnit Tests
  * Simplify tests by using `java.net.URL` instead of an (old) framework.
  * Enable JavaScript by default for a more realistic testing environment.
  * Some little fixes
- pom.xml
  * remove [HTTPClient artifact](https://mvnrepository.com/artifact/HTTPClient/HTTPClient)
    HTTPClient was last updated in Nov, 2005
    This was only used in `OldProxyServlet.handleImageProxy()`
  * switch from [HttpUnit](https://mvnrepository.com/artifact/httpunit/httpunit) to [HtmlUnit](https://mvnrepository.com/artifact/net.sourceforge.htmlunit/htmlunit)
    HttpUnit is an old framework which is nearly never updates
  * remove [rhino:js](https://mvnrepository.com/artifact/rhino/js)
    Only necessary in combination with `HttpUnit`.
  * Make tests at least manually runable.
    Currently, test will be skipped by default. Add `skipTests` as property so that you can at least manually change it via:
    - `mvn test -DskipTests=false`
    - `mvn test -DskipTests=false -DargLine="-Dsystem.test.server=http://localhost:8080/plantuml"`