### PR TITLE
Using TCK Tested JDK builds of OpenJDK

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,14 +7,17 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        java-version: [ 8.0.192, 8 ]
     steps:
       - uses: actions/checkout@v2
         with:
           fetch-depth: 0
       - uses: actions/setup-java@v2
         with:
-          distribution: "adopt"
-          java-version: "8"
+          distribution: "zulu"
+          java-version: ${{ matrix.java-version }}
           check-latest: true
           cache: "maven"
 


### PR DESCRIPTION
The AdoptOpenJDK has been discontinued since July 2021 (https://adoptopenjdk.net). Switching the distribution to Azul Zulu. When using Zulu you get all the latest updated (TCK Tested) builds for all versions of OpenJDK. 

Also added is a fixed (major) release version(s) such as `JDK 8.0.192`. This is often a good practice whenever a build/test triggers (push/pull events) to help determine if the latest (`JDK 8`) had failed the from the **latest build** vs something in **your code** caused (or introduced). 

**For example**, when building with `JDK 8.0.192` (fixed version) the build/tests passes (Green) and JDK 8 fails (Red) will mean that the latest `JDK 8` was the cause and not your code. 

**Note:** Other distributions such as Temurin do not support archived fixed releases prior to Sept. 2021 and many non LTS (long term support) releases if you plan to try out newer features in the language.