### PR TITLE
Update and restructure pom.xml and add missing javadoc

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,4 +1,5 @@
 name: Main
+
 on:
   push:
     tags:
@@ -11,6 +12,7 @@ jobs:
       - uses: actions/checkout@v2
         with:
           fetch-depth: 0
+
       - uses: actions/setup-java@v2
         with:
           distribution: "adopt"

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,34 @@
+name: Pages
+
+on:
+  workflow_dispatch:
+  workflow_run:
+    workflows:
+      - Main
+    types:
+      - completed
+
+jobs:
+  pages:
+    runs-on: ubuntu-latest
+    if: github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success'
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-java@v2
+        with:
+          distribution: "adopt"
+          java-version: "8"
+          check-latest: true
+          cache: "maven"
+
+      - name: Create GitHub Pages
+        run: mvn site
+
+      - name: Deploy GitHub Pages
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./target/site

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,141 @@
+name: Tests
+
+on:
+  - push
+  - pull_request
+
+jobs:
+  test-mvn-livecycle:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-java@v2
+        with:
+          distribution: "adopt"
+          java-version: "8"
+          check-latest: true
+          cache: "maven"
+
+      - name: Lifecycle - Step 1/8 - mvn clean
+        run: mvn clean
+
+      - name: Lifecycle - Step 2/8 - mvn validate
+        run: mvn validate
+        
+      - name: Lifecycle - Step 3/8 - mvn compile
+        run: mvn compile
+
+      - name: Lifecycle - Step 4/8 - mvn test (with skipTests=true)
+        run: mvn test
+
+      - name: Lifecycle - Step 5/8 - mvn package
+        run: mvn package
+
+      - name: Lifecycle - Step 6/8 - mvn verify
+        run: mvn verify
+
+      - name: Lifecycle - Step 7/8 - mvn install
+        run: mvn install
+
+      - name: Lifecycle - Step 8/8 - mvn site
+        run: mvn site
+
+  # test-embedded:
+  #   runs-on: ubuntu-latest
+  #   needs: test-mvn-livecycle
+  #   steps:
+  #     - uses: actions/checkout@v2
+  #       with:
+  #         fetch-depth: 0
+
+  #     - uses: actions/setup-java@v2
+  #       with:
+  #         distribution: "adopt"
+  #         java-version: "8"
+  #         check-latest: true
+  #         cache: "maven"
+
+  #     - name: Prepare embedded tests - Step 1/3 - mvn clean
+  #       run: mvn clean
+        
+  #     - name: Prepare embedded tests - Step 2/3 - mvn compile
+  #       run: mvn compile
+
+  #     - name: Prepare embedded tests - Step 3/3 - mvn test (with skipTests=true)
+  #       run: mvn test
+
+  #     - name: Run tests against jetty embedded server
+  #       run: mvn test -DskipTests=false
+
+  test-jetty:
+    runs-on: ubuntu-latest
+    needs: test-mvn-livecycle
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-java@v2
+        with:
+          distribution: "adopt"
+          java-version: "8"
+          check-latest: true
+          cache: "maven"
+
+      - name: Prepare external tests - Step 1/3 - mvn clean
+        run: mvn clean
+        
+      - name: Prepare external tests - Step 2/3 - mvn compile
+        run: mvn compile
+
+      - name: Prepare external tests - Step 3/3 - mvn test (with skipTests=true)
+        run: mvn test
+
+      - name: Build the jetty docker stack
+        run: |
+          docker image build -f Dockerfile.jetty -t plantuml-server:local .
+          docker run -d -p 8080:8080 -e BASE_URL=plantuml plantuml-server:local
+
+      - name: Check running containers
+        run: docker ps
+
+      - name: run tests against jetty docker image
+        run: mvn test -DskipTests=false -DargLine="-Dsystem.test.server=http://localhost:8080/plantuml"
+
+  test-tomcat:
+    runs-on: ubuntu-latest
+    needs: test-mvn-livecycle
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-java@v2
+        with:
+          distribution: "adopt"
+          java-version: "8"
+          check-latest: true
+          cache: "maven"
+
+      - name: Prepare external tests - Step 1/3 - mvn clean
+        run: mvn clean
+        
+      - name: Prepare external tests - Step 2/3 - mvn compile
+        run: mvn compile
+
+      - name: Prepare external tests - Step 3/3 - mvn test (with skipTests=true)
+        run: mvn test
+
+      - name: Build the tomcat docker stack
+        run: |
+          docker image build -f Dockerfile.tomcat -t plantuml-server:local .
+          docker run -d -p 8080:8080 -e BASE_URL=plantuml plantuml-server:local
+
+      - name: Check running containers
+        run: docker ps
+
+      - name: run tests against tomcat docker image
+        run: mvn test -DskipTests=false -DargLine="-Dsystem.test.server=http://localhost:8080/plantuml"

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -13,7 +13,8 @@
         "servlet",
         "servlets",
         "startditaa",
-        "startuml"
+        "startuml",
+        "utxt"
     ],
     "cSpell.allowCompoundWords": true
 }

--- a/README.md
+++ b/README.md
@@ -1,7 +1,13 @@
 # PlantUML Server
 
-![workflow status](https://github.com/plantuml/plantuml-server/actions/workflows/main.yml/badge.svg)
-[![docker pulls](https://img.shields.io/docker/pulls/plantuml/plantuml-server.svg)](https://hub.docker.com/r/plantuml/plantuml-server)
+[![GNU GENERAL PUBLIC LICENSE, Version 3, 29 June 2007](https://img.shields.io/github/license/plantuml/plantuml-server.svg?color=blue)](https://www.gnu.org/licenses/gpl-3.0)
+[![latest tag](https://img.shields.io/github/v/tag/plantuml/plantuml-server)](https://github.com/plantuml/plantuml-server/tags)
+![workflow status (Main)](https://github.com/plantuml/plantuml-server/actions/workflows/main.yml/badge.svg)
+![workflow status (Tests)](https://github.com/plantuml/plantuml-server/actions/workflows/tests.yml/badge.svg)
+![workflow status (Pages)](https://github.com/plantuml/plantuml-server/actions/workflows/pages.yml/badge.svg)  
+[![docker pulls](https://img.shields.io/docker/pulls/plantuml/plantuml-server.svg?color=blue)](https://hub.docker.com/r/plantuml/plantuml-server)
+![Docker Image Size (Jetty)](https://img.shields.io/docker/image-size/plantuml/plantuml-server/jetty?label=jetty%20image%20size)
+![Docker Image Size (Tomcat)](https://img.shields.io/docker/image-size/plantuml/plantuml-server/tomcat?label=tomcat%20image%20size)
 
 PlantUML Server is a web application to generate UML diagrams on-the-fly.
 
@@ -84,21 +90,21 @@ docker run -d -p 8080:8080 -e THE_ENV_VARIABLE=THE_ENV_VALUE plantuml/plantuml-s
 
 You can set all  the following variables:
 
+* `BASE_URL`
+  * PlantUML Base URL path
+  * Default value: `ROOT`
 * `PLANTUML_LIMIT_SIZE`
-    * Limits image width and height
-    * Default value: `4096`
-* `GRAPHVIZ_DOT`
-    * Link to 'dot' executable
-    * Default value: `/usr/local/bin/dot` or `/usr/bin/dot`
+  * Limits image width and height
+  * Default value: `4096`
 * `PLANTUML_STATS`
-    * Set it to `on` to enable [statistics report](https://plantuml.com/statistics-report)
-    * Default value: `off`
+  * Set it to `on` to enable [statistics report](https://plantuml.com/statistics-report)
+  * Default value: `off`
 * `HTTP_AUTHORIZATION`
-    * when calling the `proxy` endpoint, the value of `HTTP_AUTHORIZATION` will be used to set the HTTP Authorization header
-    * Default value: `null`
+  * when calling the `proxy` endpoint, the value of `HTTP_AUTHORIZATION` will be used to set the HTTP Authorization header
+  * Default value: `null`
 * `ALLOW_PLANTUML_INCLUDE`
-    * Enables `!include` processing which can read files from the server into diagrams. Files are read relative to the current working directory.
-    * Default value: `false`
+  * Enables `!include` processing which can read files from the server into diagrams. Files are read relative to the current working directory.
+  * Default value: `false`
 
 
 ## Alternate: How to build your docker image
@@ -112,7 +118,7 @@ So, you can use following command to create a self-contained docker image that w
 docker image build -t plantuml-server:local .
 docker run -d -p 8080:8080 plantuml-server:local
 ```
-The server is now listening to [http://localhost:8080/plantuml](http://localhost:8080/plantuml).
+The server is now listening to [http://localhost:8080](http://localhost:8080).
 
 You may specify the port in `-p` Docker command line argument.
 

--- a/pom.xml
+++ b/pom.xml
@@ -1,226 +1,138 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project
+  xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd"
+>
   <modelVersion>4.0.0</modelVersion>
+
   <groupId>org.sourceforge.plantuml</groupId>
   <artifactId>plantumlservlet</artifactId>
   <version>1-SNAPSHOT</version>
-  <name>PlantUML Servlet</name>
   <packaging>war</packaging>
-  <build>
-    <finalName>plantuml</finalName>
-    <pluginManagement>
-      <plugins>
-        <plugin>
-          <groupId>org.apache.maven.plugins</groupId>
-          <artifactId>maven-checkstyle-plugin</artifactId>
-          <version>3.1.2</version>
-          <dependencies>
-            <dependency>
-              <groupId>com.puppycrawl.tools</groupId>
-              <artifactId>checkstyle</artifactId>
-              <version>9.0.1</version>
-            </dependency>
-          </dependencies>
-          <configuration>
-            <configLocation>${basedir}/src/main/config/checkstyle.xml</configLocation>
-            <linkXRef>false</linkXRef>
-            <consoleOutput>true</consoleOutput>
-            <failsOnError>true</failsOnError>
-          </configuration>
-        </plugin>
-      </plugins>
-    </pluginManagement>
-    <plugins>
-      <plugin>
-        <artifactId>maven-eclipse-plugin</artifactId>
-        <version>2.8</version>
-        <configuration>
-          <wtpversion>1.5</wtpversion>
-          <wtpContextName>plantuml</wtpContextName>
-        </configuration>
-      </plugin>
-      <plugin>
-        <artifactId>maven-compiler-plugin</artifactId>
-        <version>2.3.2</version>
-        <configuration>
-          <source>1.7</source>
-          <target>1.7</target>
-        </configuration>
-      </plugin>
-      <plugin>
-        <groupId>org.mortbay.jetty</groupId>
-        <artifactId>jetty-maven-plugin</artifactId>
-        <version>${jetty.version}</version>
-        <configuration>
-          <scanIntervalSeconds>5</scanIntervalSeconds>
-          <webApp>
-            <contextPath>${jetty.contextpath}</contextPath>
-          </webApp>
-          <systemProperties>
-            <systemProperty>
-              <name>jetty.port</name>
-              <value>${jetty.port}</value>
-            </systemProperty>
-          </systemProperties>
-        </configuration>
-      </plugin>
-        <plugin>
-            <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-dependency-plugin</artifactId>
-            <version>2.3</version>
-            <executions>
-                <execution>
-                    <phase>package</phase>
-                    <goals><goal>copy</goal></goals>
-                    <configuration>
-                        <artifactItems>
-                            <artifactItem>
-                                <groupId>org.mortbay.jetty</groupId>
-                                <artifactId>jetty-runner</artifactId>
-                                <version>8.1.9.v20130131</version>
-                                <destFileName>jetty-runner.jar</destFileName>
-                            </artifactItem>
-                        </artifactItems>
-                    </configuration>
-                </execution>
-            </executions>
-        </plugin>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-war-plugin</artifactId>
-        <version>2.3</version>
-        <configuration>
-          <webResources>
-            <resource>
-              <directory>src/main/webapp</directory>
-              <includes>
-                <include>*.jspf</include>
-              </includes>
-              <filtering>true</filtering>
-            </resource>
-          </webResources>
-        </configuration>
-      </plugin>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-surefire-plugin</artifactId>
-        <version>2.14.1</version>
-        <configuration>
-          <skipTests>${skipTests}</skipTests>
-        </configuration>
-      </plugin>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-site-plugin</artifactId>
-        <version>3.0-beta-3</version>
-      </plugin>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-checkstyle-plugin</artifactId>
-        <version>3.1.2</version>
-        <executions>
-          <execution>
-            <?m2e execute onConfiguration,onIncremental?>
-            <phase>validate</phase>
-            <goals>
-              <goal>check</goal>
-            </goals>
-          </execution>
-        </executions>
-      </plugin>
-    </plugins>
-  </build>
-  <reporting>
-    <plugins>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-project-info-reports-plugin</artifactId>
-        <version>2.6</version>
-        <reportSets>
-          <reportSet>
-            <reports><!-- select reports -->
-              <report>index</report>
-              <report>dependencies</report>
-            </reports>
-          </reportSet>
-        </reportSets>
-      </plugin>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-javadoc-plugin</artifactId>
-        <version>3.3.1</version>
-        <configuration>
-          <show>private</show>
-          <nohelp>true</nohelp>
-        </configuration>
-        <reportSets>
-          <reportSet>
-            <id>html</id>
-            <reports>
-              <report>javadoc</report>
-            </reports>
-          </reportSet>
-        </reportSets>
-      </plugin>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-checkstyle-plugin</artifactId>
-        <version>3.1.2</version>
-        <reportSets>
-          <reportSet>
-            <reports>
-              <report>checkstyle</report>
-              <report>checkstyle-aggregate</report>
-            </reports>
-          </reportSet>
-        </reportSets>
-      </plugin>
-    </plugins>
-  </reporting>
+
+  <name>PlantUML Servlet</name>
+  <url>https://plantuml.github.io/plantuml-server/index.html</url>
+
   <properties>
+    <java.version>8</java.version>
+    <maven.compiler.source>${java.version}</maven.compiler.source>
+    <maven.compiler.target>${java.version}</maven.compiler.target>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-    <jetty.version>8.0.4.v20111024</jetty.version>
-    <jetty.port>8080</jetty.port>
-    <jetty.contextpath>/plantuml</jetty.contextpath>
-    <maven.build.timestamp.format>yyyyMMdd-HHmm
-    </maven.build.timestamp.format>
-    <timestamp>${maven.build.timestamp}</timestamp>
+
+    <!--
+      Skip tests by default.
+      Run tests manually:
+        - mvn test -DskipTests=false
+        - mvn test -DskipTests=false -DargLine="-Dsystem.test.server=http://localhost:8080/plantuml"
+    -->
     <skipTests>true</skipTests>
+
+    <maven.build.timestamp.format>yyyyMMdd-HHmm</maven.build.timestamp.format>
+    <timestamp>${maven.build.timestamp}</timestamp>
+
+    <wtp.version>1.5</wtp.version>
+    <wtp.contextName>plantuml</wtp.contextName>
+
+    <jetty.port>8080</jetty.port>
+    <jetty.contextpath>/${wtp.contextName}</jetty.contextpath>
+
+    <!-- main versions -->
+    <plantuml.version>1.2021.12</plantuml.version>
+    <jetty.version>8.0.4.v20111024</jetty.version>
+    <codemirror.version>5.63.0</codemirror.version>
+
+    <!-- dependencies -->
+    <jstl.version>1.2</jstl.version>
+    <servlet-api.version>2.5</servlet-api.version>
+    <batik-all.version>1.14</batik-all.version>
+    <!-- jlatexmath -->
+    <jlatexmath.version>1.0.7</jlatexmath.version>
+    <jlatexmath-font-greek.version>${jlatexmath.version}</jlatexmath-font-greek.version>
+    <jlatexmath-font-cyrillic.version>${jlatexmath.version}</jlatexmath-font-cyrillic.version>
+    <!-- Testing -->
+    <junit.version>4.13.2</junit.version>
+    <htmlunit.version>2.53.0</htmlunit.version>
+
+    <!-- build plugin management -->
+    <!-- lock down plugins versions to avoid using Maven defaults -->
+    <maven-clean-plugin.version>3.1.0</maven-clean-plugin.version>
+    <maven-dependency-plugin.version>3.2.0</maven-dependency-plugin.version>
+    <maven-resources-plugin.version>3.2.0</maven-resources-plugin.version>
+    <maven-compiler-plugin.version>3.8.1</maven-compiler-plugin.version>
+    <versions-maven-plugin.version>2.8.1</versions-maven-plugin.version>
+    <maven-surefire-plugin.version>2.22.2</maven-surefire-plugin.version>
+    <maven-war-plugin.version>3.3.2</maven-war-plugin.version>
+    <maven-install-plugin.version>2.5.2</maven-install-plugin.version>
+    <maven-deploy-plugin.version>2.8.2</maven-deploy-plugin.version>
+    <maven-site-plugin.version>3.9.1</maven-site-plugin.version>
+    <maven-project-info-reports-plugin.version>3.1.2</maven-project-info-reports-plugin.version>
+    <maven-checkstyle-plugin.version>3.1.2</maven-checkstyle-plugin.version>
+    <checkstyle.version>9.0.1</checkstyle.version>
+
+    <!-- plugins -->
+    <maven-eclipse-plugin.version>2.10</maven-eclipse-plugin.version>
+    <!-- <jetty-runner.version>${jetty.version}</jetty-runner.version> -->
+    <jetty-runner.version>8.1.9.v20130131</jetty-runner.version>
+    <jetty-maven-plugin.version>${jetty.version}</jetty-maven-plugin.version>
+    <maven-javadoc-plugin.version>3.3.1</maven-javadoc-plugin.version>
   </properties>
+  
   <dependencies>
     <dependency>
       <groupId>net.sourceforge.plantuml</groupId>
       <artifactId>plantuml</artifactId>
-      <version>1.2021.12</version>
+      <version>${plantuml.version}</version>
     </dependency>
     <dependency>
       <groupId>javax.servlet</groupId>
       <artifactId>jstl</artifactId>
-      <version>1.2</version>
+      <version>${jstl.version}</version>
     </dependency>
     <dependency>
-      <groupId>org.webjars</groupId>
+      <groupId>org.webjars.npm</groupId>
       <artifactId>codemirror</artifactId>
-      <version>3.21</version>
+      <version>${codemirror.version}</version>
     </dependency>
     <dependency>
       <groupId>javax.servlet</groupId>
       <artifactId>servlet-api</artifactId>
-      <version>2.5</version>
+      <version>${servlet-api.version}</version>
       <scope>provided</scope>
     </dependency>
     <dependency>
+      <groupId>org.apache.xmlgraphics</groupId>
+      <artifactId>batik-all</artifactId>
+      <version>${batik-all.version}</version>
+    </dependency>
+    <!-- jlatexmath -->
+    <dependency>
+      <groupId>org.scilab.forge</groupId>
+      <artifactId>jlatexmath</artifactId>
+      <version>${jlatexmath.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.scilab.forge</groupId>
+      <artifactId>jlatexmath-font-greek</artifactId>
+      <version>${jlatexmath-font-greek.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.scilab.forge</groupId>
+      <artifactId>jlatexmath-font-cyrillic</artifactId>
+      <version>${jlatexmath-font-cyrillic.version}</version>
+    </dependency>
+    <!-- Testing -->
+    <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
-      <version>4.13.2</version>
+      <version>${junit.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>net.sourceforge.htmlunit</groupId>
       <artifactId>htmlunit</artifactId>
-      <version>2.53.0</version>
+      <version>${htmlunit.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -235,25 +147,266 @@
       <version>2.1.v20100127</version>
       <scope>test</scope>
     </dependency>
-    <dependency>
-    	<groupId>org.scilab.forge</groupId>
-    	<artifactId>jlatexmath</artifactId>
-    	<version>1.0.7</version>
-    </dependency>
-    <dependency>
-    	<groupId>org.scilab.forge</groupId>
-    	<artifactId>jlatexmath-font-greek</artifactId>
-    	<version>1.0.7</version>
-    </dependency>
-    <dependency>
-    	<groupId>org.scilab.forge</groupId>
-    	<artifactId>jlatexmath-font-cyrillic</artifactId>
-    	<version>1.0.7</version>
-    </dependency>
-    <dependency>
-        <groupId>org.apache.xmlgraphics</groupId>
-	<artifactId>batik-all</artifactId>
-	<version>1.12</version>
-    </dependency>
   </dependencies>
+
+  <build>
+    <finalName>plantuml</finalName>
+
+    <pluginManagement>
+      <plugins>
+        <plugin>
+          <artifactId>maven-clean-plugin</artifactId>
+          <version>${maven-clean-plugin.version}</version>
+        </plugin>
+        <plugin>
+          <artifactId>maven-dependency-plugin</artifactId>
+          <version>${maven-dependency-plugin.version}</version>
+        </plugin>      
+        <plugin>
+          <artifactId>maven-resources-plugin</artifactId>
+          <version>${maven-resources-plugin.version}</version>
+        </plugin>
+        <plugin>
+          <artifactId>maven-compiler-plugin</artifactId>
+          <version>${maven-compiler-plugin.version}</version>
+        </plugin>
+        <plugin>
+          <artifactId>maven-surefire-plugin</artifactId>
+          <version>${maven-surefire-plugin.version}</version>
+        </plugin>
+        <plugin>
+          <artifactId>maven-war-plugin</artifactId>
+          <version>${maven-war-plugin.version}</version>
+        </plugin>
+        <plugin>
+          <artifactId>maven-install-plugin</artifactId>
+          <version>${maven-install-plugin.version}</version>
+        </plugin>
+        <plugin>
+          <artifactId>maven-deploy-plugin</artifactId>
+          <version>${maven-deploy-plugin.version}</version>
+        </plugin>
+        <plugin>
+          <artifactId>maven-site-plugin</artifactId>
+          <version>${maven-site-plugin.version}</version>
+        </plugin>
+        <plugin>
+          <artifactId>maven-project-info-reports-plugin</artifactId>
+          <version>${maven-project-info-reports-plugin.version}</version>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-checkstyle-plugin</artifactId>
+          <version>${maven-checkstyle-plugin.version}</version>
+          <dependencies>
+            <dependency>
+              <groupId>com.puppycrawl.tools</groupId>
+              <artifactId>checkstyle</artifactId>
+              <version>${checkstyle.version}</version>
+            </dependency>
+          </dependencies>
+          <configuration>
+            <configLocation>${basedir}/src/main/config/checkstyle.xml</configLocation>
+            <linkXRef>false</linkXRef>
+            <consoleOutput>true</consoleOutput>
+            <failsOnError>true</failsOnError>
+          </configuration>
+        </plugin>
+        <plugin>
+          <groupId>org.codehaus.mojo</groupId>
+          <artifactId>versions-maven-plugin</artifactId>
+          <version>${versions-maven-plugin.version}</version>
+          <configuration>
+            <outputFile>${project.build.directory}/outdated-dependencies.txt</outputFile>
+            <rulesUri>file:///${basedir}/src/main/config/rules.xml</rulesUri>
+          </configuration>
+        </plugin>
+      </plugins>
+    </pluginManagement>
+
+    <plugins>
+      <plugin>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>${maven-compiler-plugin.version}</version>
+        <configuration>
+          <source>${maven.compiler.source}</source>
+          <target>${maven.compiler.target}</target>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <version>${maven-surefire-plugin.version}</version>
+        <configuration>
+          <skipTests>${skipTests}</skipTests>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-site-plugin</artifactId>
+        <version>${maven-site-plugin.version}</version>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-checkstyle-plugin</artifactId>
+        <version>${maven-checkstyle-plugin.version}</version>
+        <executions>
+          <execution>
+            <?m2e execute onConfiguration,onIncremental?>
+            <phase>validate</phase>
+            <goals>
+              <goal>check</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>versions-maven-plugin</artifactId>
+        <version>${versions-maven-plugin.version}</version>
+        <executions>
+          <execution>
+            <phase>validate</phase>
+            <goals>
+              <goal>display-property-updates</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-javadoc-plugin</artifactId>
+        <version>${maven-javadoc-plugin.version}</version>
+        <configuration>
+          <show>private</show>
+          <nohelp>true</nohelp>
+          <source>${java.version}</source>
+          <failOnWarnings>true</failOnWarnings>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-eclipse-plugin</artifactId>
+        <version>${maven-eclipse-plugin.version}</version>
+        <configuration>
+          <wtpversion>${wtp.version}</wtpversion>
+          <wtpContextName>${wtp.contextName}</wtpContextName>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.mortbay.jetty</groupId>
+        <artifactId>jetty-maven-plugin</artifactId>
+        <version>${jetty-maven-plugin.version}</version>
+        <configuration>
+          <scanIntervalSeconds>5</scanIntervalSeconds>
+          <webApp>
+            <contextPath>${jetty.contextpath}</contextPath>
+          </webApp>
+          <systemProperties>
+            <systemProperty>
+              <name>jetty.port</name>
+              <value>${jetty.port}</value>
+            </systemProperty>
+          </systemProperties>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-dependency-plugin</artifactId>
+        <version>${maven-dependency-plugin.version}</version>
+        <executions>
+          <execution>
+            <phase>package</phase>
+            <goals>
+              <goal>copy</goal>
+            </goals>
+            <configuration>
+              <artifactItems>
+                <artifactItem>
+                  <groupId>org.mortbay.jetty</groupId>
+                  <artifactId>jetty-runner</artifactId>
+                  <version>${jetty-runner.version}</version>
+                  <destFileName>jetty-runner.jar</destFileName>
+                </artifactItem>
+              </artifactItems>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-war-plugin</artifactId>
+        <version>${maven-war-plugin.version}</version>
+        <configuration>
+          <webResources>
+            <resource>
+              <directory>src/main/webapp</directory>
+              <includes>
+                <include>*.jspf</include>
+              </includes>
+              <filtering>true</filtering>
+            </resource>
+          </webResources>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+
+  <reporting>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-project-info-reports-plugin</artifactId>
+        <version>${maven-project-info-reports-plugin.version}</version>
+        <reportSets>
+          <reportSet>
+            <reports>
+              <report>index</report>
+              <report>dependencies</report>
+            </reports>
+          </reportSet>
+        </reportSets>
+      </plugin>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>versions-maven-plugin</artifactId>
+        <version>${versions-maven-plugin.version}</version>
+        <reportSets>
+          <reportSet>
+            <reports>
+              <!-- <report>dependency-updates-report</report> -->
+              <!-- <report>plugin-updates-report</report> -->
+              <report>property-updates-report</report>
+            </reports>
+          </reportSet>
+        </reportSets>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-javadoc-plugin</artifactId>
+        <version>${maven-javadoc-plugin.version}</version>
+        <reportSets>
+          <reportSet>
+            <id>html</id>
+            <reports>
+              <report>javadoc</report>
+            </reports>
+          </reportSet>
+        </reportSets>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-checkstyle-plugin</artifactId>
+        <version>${maven-checkstyle-plugin.version}</version>
+        <reportSets>
+          <reportSet>
+            <reports>
+              <report>checkstyle</report>
+              <report>checkstyle-aggregate</report>
+            </reports>
+          </reportSet>
+        </reportSets>
+      </plugin>
+    </plugins>
+  </reporting>
 </project>

--- a/src/main/config/rules.xml
+++ b/src/main/config/rules.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ruleset
+  comparisonMethod="maven"
+  xmlns="http://mojo.codehaus.org/versions-maven-plugin/rule/2.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://mojo.codehaus.org/versions-maven-plugin/rule/2.0.0 https://www.mojohaus.org/versions-maven-plugin/xsd/rule-2.0.0.xsd"
+>
+  <ignoreVersions>
+    <!-- Ignore Alpha's, Beta's, release candidates and milestones -->
+    <ignoreVersion type="regex">(?i).*Alpha(?:-?\d+)?</ignoreVersion>
+    <ignoreVersion type="regex">(?i).*a(?:-?\d+)?</ignoreVersion>
+    <ignoreVersion type="regex">(?i).*Beta(?:-?\d+)?</ignoreVersion>
+    <ignoreVersion type="regex">(?i).*-B(?:-?\d+)?</ignoreVersion>
+    <ignoreVersion type="regex">(?i).*RC(?:-?\d+)?</ignoreVersion>
+    <ignoreVersion type="regex">(?i).*CR(?:-?\d+)?</ignoreVersion>
+    <ignoreVersion type="regex">(?i).*M(?:-?\d+)?</ignoreVersion>
+  </ignoreVersions>
+  <rules>
+    <rule groupId="net.sourceforge.plantuml" artifactId="plantuml" comparisonMethod="maven">
+      <ignoreVersions>
+        <!-- allow only version like this: 1.20XX.X* -->
+        <ignoreVersion type="regex"><![CDATA[^(.(?<!1\.20.{2}\.\d))*?$]]></ignoreVersion>
+      </ignoreVersions>
+    </rule>
+  </rules>
+</ruleset>

--- a/src/main/java/net/sourceforge/plantuml/servlet/DiagramResponse.java
+++ b/src/main/java/net/sourceforge/plantuml/servlet/DiagramResponse.java
@@ -48,41 +48,69 @@ import net.sourceforge.plantuml.version.Version;
 import net.sourceforge.plantuml.error.PSystemError;
 import net.sourceforge.plantuml.ErrorUml;
 
-
 /**
  * Delegates the diagram generation from the UML source and the filling of the HTTP response with the diagram in the
  * right format. Its own responsibility is to produce the right HTTP headers.
  */
 public class DiagramResponse {
 
+    /**
+     * {@link FileFormat} to http content type mapping.
+     */
+    private static final Map<FileFormat, String> CONTENT_TYPE;
+    /**
+     * X-Powered-By http header value included in every response by default.
+     */
     private static final String POWERED_BY = "PlantUML Version " + Version.versionString();
 
-    private HttpServletResponse response;
-    private FileFormat format;
-    private HttpServletRequest request;
-    private static final Map<FileFormat, String> CONTENT_TYPE;
-    static {
-        Map<FileFormat, String> map = new HashMap<FileFormat, String>();
-        map.put(FileFormat.PNG, "image/png");
-        map.put(FileFormat.SVG, "image/svg+xml");
-        map.put(FileFormat.EPS, "application/postscript");
-        map.put(FileFormat.UTXT, "text/plain;charset=UTF-8");
-        map.put(FileFormat.BASE64, "text/plain; charset=x-user-defined");
-        CONTENT_TYPE = Collections.unmodifiableMap(map);
-    }
     static {
         OptionFlags.ALLOW_INCLUDE = false;
         if ("true".equalsIgnoreCase(System.getenv("ALLOW_PLANTUML_INCLUDE"))) {
             OptionFlags.ALLOW_INCLUDE = true;
         }
+        CONTENT_TYPE = Collections.unmodifiableMap(new HashMap<FileFormat, String>() {{
+            put(FileFormat.PNG, "image/png");
+            put(FileFormat.SVG, "image/svg+xml");
+            put(FileFormat.EPS, "application/postscript");
+            put(FileFormat.UTXT, "text/plain;charset=UTF-8");
+            put(FileFormat.BASE64, "text/plain; charset=x-user-defined");
+        }});
     }
 
-    public DiagramResponse(HttpServletResponse r, FileFormat f, HttpServletRequest rq) {
-        response = r;
-        format = f;
-        request = rq;
+    /**
+     * Response format.
+     */
+    private FileFormat format;
+    /**
+     * Http request.
+     */
+    private HttpServletRequest request;
+    /**
+     * Http response.
+     */
+    private HttpServletResponse response;
+
+    /**
+     * Create new diagram response instance.
+     *
+     * @param res http response
+     * @param fmt target file format
+     * @param req http request
+     */
+    public DiagramResponse(HttpServletResponse res, FileFormat fmt, HttpServletRequest req) {
+        response = res;
+        format = fmt;
+        request = req;
     }
 
+    /**
+     * Render and send a specific uml diagram.
+     *
+     * @param uml textual UML diagram(s) source
+     * @param idx diagram index of {@code uml} to send
+     *
+     * @throws IOException if an input or output exception occurred
+     */
     public void sendDiagram(String uml, int idx) throws IOException {
         response.addHeader("Access-Control-Allow-Origin", "*");
         response.setContentType(getContentType());
@@ -114,6 +142,13 @@ public class DiagramResponse {
         diagram.exportDiagram(response.getOutputStream(), idx, new FileFormatOption(format));
     }
 
+    /**
+     * Is block uml unmodified?
+     *
+     * @param blockUml block uml
+     *
+     * @return true if unmodified; otherwise false
+     */
     private boolean notModified(BlockUml blockUml) {
         final String ifNoneMatch = request.getHeader("If-None-Match");
         final long ifModifiedSince = request.getDateHeader("If-Modified-Since");
@@ -127,7 +162,13 @@ public class DiagramResponse {
         return ifNoneMatch.contains(etag);
     }
 
-
+    /**
+     * Produce and send the image map of the uml diagram in HTML format.
+     *
+     * @param uml textual UML diagram source
+     *
+     * @throws IOException if an input or output exception occurred
+     */
     public void sendMap(String uml) throws IOException {
         response.setContentType(getContentType());
         SourceStringReader reader = new SourceStringReader(uml);
@@ -145,15 +186,29 @@ public class DiagramResponse {
         }
     }
 
+    /**
+     * Check the syntax of the diagram and send a report in TEXT format.
+     *
+     * @param uml textual UML diagram source
+     *
+     * @throws IOException if an input or output exception occurred
+     */
     public void sendCheck(String uml) throws IOException {
         response.setContentType(getContentType());
         SourceStringReader reader = new SourceStringReader(uml);
         DiagramDescription desc = reader.outputImage(
-            new NullOutputStream(), new FileFormatOption(FileFormat.PNG, false));
+            new NullOutputStream(),
+            new FileFormatOption(FileFormat.PNG, false)
+        );
         PrintWriter httpOut = response.getWriter();
         httpOut.print(desc.getDescription());
     }
 
+    /**
+     * Add default header including cache headers to response.
+     *
+     * @param blockUml response block uml
+     */
     private void addHeaderForCache(BlockUml blockUml) {
         long today = System.currentTimeMillis();
         // Add http headers to force the browser to cache the image
@@ -177,12 +232,22 @@ public class DiagramResponse {
         addHeaders(response);
     }
 
+    /**
+     * Add default headers to response.
+     *
+     * @param response http response
+     */
     public static void addHeaders(HttpServletResponse response) {
         response.addHeader("X-Powered-By", POWERED_BY);
         response.addHeader("X-Patreon", "Support us on https://plantuml.com/patreon");
         response.addHeader("X-Donate", "https://plantuml.com/paypal");
     }
 
+    /**
+     * Get response content type.
+     *
+     * @return response content type
+     */
     private String getContentType() {
         return CONTENT_TYPE.get(format);
     }

--- a/src/main/java/net/sourceforge/plantuml/servlet/MapServlet.java
+++ b/src/main/java/net/sourceforge/plantuml/servlet/MapServlet.java
@@ -32,7 +32,6 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
 import net.sourceforge.plantuml.FileFormat;
-
 import net.sourceforge.plantuml.servlet.utility.UmlExtractor;
 
 /**
@@ -58,6 +57,13 @@ public class MapServlet extends HttpServlet {
         dr = null;
     }
 
+    /**
+     * Extract UML source from URI.
+     *
+     * @param uri the complete URI as returned by `request.getRequestURI()`
+     *
+     * @return the encoded UML text
+     */
     public String getSource(String uri) {
         String[] result = uri.split("/map/", 2);
         if (result.length != 2) {

--- a/src/main/java/net/sourceforge/plantuml/servlet/ProxyServlet.java
+++ b/src/main/java/net/sourceforge/plantuml/servlet/ProxyServlet.java
@@ -102,6 +102,15 @@ public class ProxyServlet extends HttpServlet {
         dr = null;
     }
 
+    /**
+     * Get textual uml diagram source from URL.
+     *
+     * @param url source URL
+     *
+     * @return textual uml diagram source
+     *
+     * @throws IOException if an input or output exception occurred
+     */
     private String getSource(final URL url) throws IOException {
         String line;
         BufferedReader rd;
@@ -124,6 +133,14 @@ public class ProxyServlet extends HttpServlet {
         return "";
     }
 
+    /**
+     * Get {@link FileFormat} instance from string.
+     *
+     * @param format file format name
+     *
+     * @return corresponding file format instance,
+     *         if {@code format} is null or unknown the default {@link FileFormat#PNG} will be returned
+     */
     private FileFormat getOutputFormat(String format) {
         if (format == null) {
             return FileFormat.PNG;
@@ -143,6 +160,15 @@ public class ProxyServlet extends HttpServlet {
         return FileFormat.PNG;
     }
 
+    /**
+     * Get open http connection from URL.
+     *
+     * @param url URL to open connection
+     *
+     * @return open http connection
+     *
+     * @throws IOException if an input or output exception occurred
+     */
     private HttpURLConnection getConnection(final URL url) throws IOException {
         final HttpURLConnection con = (HttpURLConnection) url.openConnection();
         //if (con instanceof HttpsURLConnection) {
@@ -159,7 +185,8 @@ public class ProxyServlet extends HttpServlet {
     }
 
     /**
-     * Debug method used to dump the certificate info
+     * Debug method used to dump the certificate info.
+     *
      * @param con the https connection
      */
     @SuppressWarnings("unused")

--- a/src/main/java/net/sourceforge/plantuml/servlet/UmlDiagramService.java
+++ b/src/main/java/net/sourceforge/plantuml/servlet/UmlDiagramService.java
@@ -43,6 +43,11 @@ import java.util.regex.Pattern;
 @SuppressWarnings("SERIAL")
 public abstract class UmlDiagramService extends HttpServlet {
 
+    /**
+     * Regex pattern to fetch encoded uml text from an URL.
+     */
+    private static final Pattern RECOVER_UML_PATTERN = Pattern.compile("/\\w+/(\\d+/)?(.*)");
+
     static {
         OptionFlags.ALLOW_INCLUDE = false;
         if ("true".equalsIgnoreCase(System.getenv("ALLOW_PLANTUML_INCLUDE"))) {
@@ -52,7 +57,6 @@ public abstract class UmlDiagramService extends HttpServlet {
 
     @Override
     public void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException, ServletException {
-
         // build the UML source from the compressed request parameter
         final String[] sourceAndIdx = getSourceAndIdx(request);
         final int idx = Integer.parseInt(sourceAndIdx[1]);
@@ -70,7 +74,6 @@ public abstract class UmlDiagramService extends HttpServlet {
 
     @Override
     public void doPost(HttpServletRequest request, HttpServletResponse response) throws IOException {
-
         // build the UML source from the compressed request parameter
         final String[] sourceAndIdx = getSourceAndIdx(request);
         final int idx = Integer.parseInt(sourceAndIdx[1]);
@@ -88,13 +91,22 @@ public abstract class UmlDiagramService extends HttpServlet {
         doDiagramResponse(request, response, uml.toString(), idx);
     }
 
+    /**
+     * Send diagram response.
+     *
+     * @param request html request
+     * @param response html response
+     * @param uml textual UML diagram(s) source
+     * @param idx diagram index of {@code uml} to send
+     *
+     * @throws IOException if an input or output exception occurred
+     */
     private void doDiagramResponse(
         HttpServletRequest request,
         HttpServletResponse response,
         String uml,
-        int idx)
-        throws IOException {
-
+        int idx
+    ) throws IOException {
         // generate the response
         DiagramResponse dr = new DiagramResponse(response, getOutputFormat(), request);
         try {
@@ -103,10 +115,7 @@ public abstract class UmlDiagramService extends HttpServlet {
             // Browser has closed the connection, so the HTTP OutputStream is closed
             // Silently catch the exception to avoid annoying log
         }
-        dr = null;
     }
-
-    private static final Pattern RECOVER_UML_PATTERN = Pattern.compile("/\\w+/(\\d+/)?(.*)");
 
     /**
      * Extracts the UML source text and its index from the HTTP request.
@@ -132,7 +141,7 @@ public abstract class UmlDiagramService extends HttpServlet {
                 return new String[]{data, idx };
             }
         }
-        return new String[]{"", "0" };
+        return new String[]{"", "0"};
     }
 
     /**

--- a/src/main/java/net/sourceforge/plantuml/servlet/utility/Configuration.java
+++ b/src/main/java/net/sourceforge/plantuml/servlet/utility/Configuration.java
@@ -28,13 +28,22 @@ import java.io.InputStream;
 
 import java.util.Properties;
 
+/**
+ * Shared PlantUML Server configuration.
+ */
 public final class Configuration {
 
+    /**
+     * Singleton configuration instance.
+     */
     private static Configuration instance;
+    /**
+     * Configuration properties.
+     */
     private Properties config;
 
     /**
-     * Singleton constructor
+     * Singleton constructor.
      */
     private Configuration() {
         config = new Properties();
@@ -57,7 +66,7 @@ public final class Configuration {
     }
 
     /**
-     * Get the configuration
+     * Get the configuration.
      *
      * @return the complete configuration
      */
@@ -69,7 +78,9 @@ public final class Configuration {
     }
 
     /**
-     * Get a boolean configuration value
+     * Get a boolean configuration value.
+     *
+     * @param key config property key
      *
      * @return true if the value is "on"
      */

--- a/src/main/java/net/sourceforge/plantuml/servlet/utility/NullOutputStream.java
+++ b/src/main/java/net/sourceforge/plantuml/servlet/utility/NullOutputStream.java
@@ -26,29 +26,19 @@ package net.sourceforge.plantuml.servlet.utility;
 import java.io.IOException;
 import java.io.OutputStream;
 
+/**
+ * This output stream ignores everything and writes nothing.
+ */
 public class NullOutputStream extends OutputStream {
 
     /**
-     * Writes to nowhere
+     * Writes to nowhere.
+     *
+     * @param b anything
      */
     @Override
     public void write(int b) throws IOException {
         // Do nothing silently
     }
 
-    /**
-     * Overridden for performance reason
-     */
-    @Override
-    public void write(byte[] b) throws IOException {
-        // Do nothing silently
-    }
-
-    /**
-     * Overridden for performance reason
-     */
-    @Override
-    public void write(byte[] b, int off, int len) throws IOException {
-        // Do nothing silently
-    }
 }

--- a/src/main/java/net/sourceforge/plantuml/servlet/utility/UmlExtractor.java
+++ b/src/main/java/net/sourceforge/plantuml/servlet/utility/UmlExtractor.java
@@ -35,7 +35,7 @@ import net.sourceforge.plantuml.code.TranscoderUtil;
  * Utility class to extract the UML source from the compressed UML source contained in the end part
  * of the requested URI.
  */
-public class UmlExtractor {
+public abstract class UmlExtractor {
 
     static {
         OptionFlags.ALLOW_INCLUDE = false;
@@ -49,6 +49,7 @@ public class UmlExtractor {
      * HTTP URI.
      *
      * @param source the last part of the URI containing the compressed UML
+     *
      * @return the textual UML source
      */
     static public String getUmlSource(String source) {
@@ -81,11 +82,6 @@ public class UmlExtractor {
             uml = plantUmlSource.toString();
         }
         return uml;
-    }
-
-    protected UmlExtractor() {
-        // prevents calls from subclass
-        throw new UnsupportedOperationException();
     }
 
 }

--- a/src/main/webapp/index.jsp
+++ b/src/main/webapp/index.jsp
@@ -28,9 +28,8 @@
     <link rel="icon" href="${hostpath}/favicon.ico" type="image/x-icon"/> 
     <link rel="shortcut icon" href="${hostpath}/favicon.ico" type="image/x-icon"/>
     <link rel="stylesheet" href="${hostpath}/plantuml.css" />
-    <link rel="stylesheet" href="${hostpath}/webjars/codemirror/3.21/lib/codemirror.css" />
-    <script src="${hostpath}/webjars/codemirror/3.21/lib/codemirror.js"></script>
-    <!-- <script src="mode/plantuml.js"></script> -->
+    <link rel="stylesheet" href="${hostpath}/webjars/codemirror/5.63.0/lib/codemirror.css" />
+    <script src="${hostpath}/webjars/codemirror/5.63.0/lib/codemirror.js"></script>
     <script>
         window.onload = function() {
             document.myCodeMirror = CodeMirror.fromTextArea(

--- a/src/test/java/net/sourceforge/plantuml/servlet/TestUtils.java
+++ b/src/test/java/net/sourceforge/plantuml/servlet/TestUtils.java
@@ -6,16 +6,16 @@ package net.sourceforge.plantuml.servlet;
  */
 public abstract class TestUtils {
 
-    /*
-     * Theses strings are the compressed form of a PlantUML diagram.
-     */
+    //
+    // Theses strings are the compressed form of a PlantUML diagram.
+    //
 
-    /*
+    /**
      * version
      */
     public static final String VERSION = "AqijAixCpmC0";
 
-    /*
+    /**
      * Bob -> Alice : hello
      */
     public static final String SEQBOB = "SyfFKj2rKt3CoKnELR1Io4ZDoSa70000";


### PR DESCRIPTION
This PR ...
- ... updates the pom.xml dependencies, except jetty.
- ... also add the thing every developer loves and hates at the same time: all missing JavaDoc comments.
- ... is one part of #189.

### Changes

- Code
  * add JavaDoc to each class, method and property inside the main code (not test code)
- pom.xml
  * restructure pom.xml and use properties to control each artifact/plugin version
  * use plugin management to lock down plugins versions to avoid using maven defaults
  * update all artifacts/plugins to latest version, except jetty
    (this would come up with to much changes for a singe PR)
    This also closes #180.
  * set javadoc plugin configuration to fail on warnings to force developer to write javadocs
    `mvn javadoc:javadoc`
  * add `versions-maven-plugin` to easily detect updateable artifacts/plugins
    `mvn versions:display-property-updates`
    (also add a version report)
  * add url tag to GitHub pages
- GitHub workflow
  * add "Tests" workflow
    This will be triggered on every push and PR and runs
    1. maven livecycle and if successfully
    2. junit test against
      - embedded jetty server (currently deactivated, because its not runnable)
      - jetty docker image
      - tomcat docker image
  * add GitHub Pages
    This will be triggered if the "Main" workflow (triggered by tag creation) if sucessfully completed.
    It is also possible to trigger this workflow manually with `workflow_dispatch`.
    This creates the maven sites and published them to https://plantuml.github.io/plantuml-server/index.html
- Readme
  * add some more badges
    - license
    - latest tag (-> PlantUML version)
    - tests workflow status
    - github pages workflow status
      **Can only be rendered after next sucessful tag creation!** Alternative: trigger workflow manually
    - docker images sizes (latest jetty and tomcat version)
