### PR TITLE
enable vertical resize for input text area

### DIFF
--- a/src/main/webapp/plantuml.css
+++ b/src/main/webapp/plantuml.css
@@ -28,6 +28,7 @@ h1, p, #content a {
     font-family: monospace;
     font-size: medium;
     width: 100%;
+    resize: vertical;
 }
 
 #content input[type=text] {


### PR DESCRIPTION
As title, enabling vertical resize to make it easier to edit a large diagram. See attached image for screenshot, note the resize icon in the right bottom
<img width="1756" alt="Screen Shot 2021-10-13 at 10 13 31 AM" src="https://user-images.githubusercontent.com/2017944/137181881-dcdbb6f8-eb1f-4160-b264-906ebf332e48.png">
