### PR TITLE
Use relative URLs only, to preserve `http` or `https` ...

### DIFF
--- a/run-jetty.sh
+++ b/run-jetty.sh
@@ -1,0 +1,32 @@
+#!/bin/bash -
+
+SERVICE=plantuml
+
+WEBSERVER=jetty
+if [[ $0 == *tomcat* ]] ; then
+    WEBSERVER=tomcat
+fi
+
+function stop-service {
+    echo Stopping $SERVICE ...
+    sudo docker stop $SERVICE 2>&1
+    sudo docker container rm -f $SERVICE 2>&1
+    echo $SERVICE stopped.
+}
+
+function start-service {
+    echo Starting $SERVICE ...
+    sudo docker run \
+	--name $SERVICE \
+	-d -p 8080:8080 \
+	-v /var/log/$SERVICE:/var/log/$WEBSERVER \
+	$SERVICE/$SERVICE-server:$WEBSERVER
+    echo $SERVICE started.
+}
+
+if [[ $1 == --stop ]] ; then
+    stop-service
+else
+    stop-service
+    start-service
+fi

--- a/run-tomcat.sh
+++ b/run-tomcat.sh
@@ -1,0 +1,1 @@
+run-jetty.sh

--- a/src/main/webapp/index.jsp
+++ b/src/main/webapp/index.jsp
@@ -6,8 +6,6 @@
     // properties
     boolean showSocialButtons = (boolean)request.getAttribute("showSocialButtons");
     boolean showGithubRibbon = (boolean)request.getAttribute("showGithubRibbon");
-    // URL base
-    String hostpath = request.getAttribute("hostpath").toString();
     // image URLs
     boolean hasImg = (boolean)request.getAttribute("hasImg");
     String imgurl = request.getAttribute("imgurl").toString();
@@ -26,11 +24,11 @@
     <meta http-equiv="expires" content="0" />
     <meta http-equiv="pragma" content="no-cache" />
     <meta http-equiv="cache-control" content="no-cache, must-revalidate" />
-    <link rel="icon" href="<%= hostpath %>/favicon.ico" type="image/x-icon"/> 
-    <link rel="shortcut icon" href="<%= hostpath %>/favicon.ico" type="image/x-icon"/>
-    <link rel="stylesheet" href="<%= hostpath %>/plantuml.css" />
-    <link rel="stylesheet" href="<%= hostpath %>/webjars/codemirror/5.63.0/lib/codemirror.css" />
-    <script src="<%= hostpath %>/webjars/codemirror/5.63.0/lib/codemirror.js"></script>
+    <link rel="icon" href="/favicon.ico" type="image/x-icon"/> 
+    <link rel="shortcut icon" href="/favicon.ico" type="image/x-icon"/>
+    <link rel="stylesheet" href="/plantuml.css" />
+    <link rel="stylesheet" href="/webjars/codemirror/5.63.0/lib/codemirror.css" />
+    <script src="/webjars/codemirror/5.63.0/lib/codemirror.js"></script>
     <script>
         window.onload = function() {
             document.myCodeMirror = CodeMirror.fromTextArea(
@@ -55,7 +53,7 @@
     </div>
     <div id="content">
         <%-- CONTENT --%>
-        <form method="post" accept-charset="utf-8"  action="<%= hostpath %>/form">
+        <form method="post" accept-charset="utf-8"  action="/form">
             <p>
                 <textarea id="text" name="text" cols="120" rows="10"><%= decoded %></textarea>
                 <input type="submit" />
@@ -63,7 +61,7 @@
         </form>
         <hr/>
         <p>You can enter here a previously generated URL:</p>
-        <form method="post" action="<%= hostpath %>/form">
+        <form method="post" action="/form">
             <p>
                 <input name="url" type="text" size="150" value="<%= imgurl %>" />
                 <br/>


### PR DESCRIPTION
 ... in case our service is sitting behind an SSL proxy like `nginx`.

Mentioned in https://github.com/plantuml/plantuml-server/issues/207