### PR TITLE
Use relative paths as far as possible.

### DIFF
--- a/examples/nginx-contextpath/README.md
+++ b/examples/nginx-contextpath/README.md
@@ -69,8 +69,8 @@ services:
     image: plantuml/plantuml-server:jetty
     container_name: plantuml-server
     environment:
-      - TZ="Europe/Berlin"
-      - BASE_URL="plantuml"
+      - TZ=Europe/Berlin
+      - BASE_URL=plantuml
 
   nginx:
     image: nginx:alpine
@@ -78,7 +78,7 @@ services:
     ports:
       - "80:80"
     environment:
-      - TZ="Europe/Berlin"
+      - TZ=Europe/Berlin
     volumes:
       - ./nginx.conf:/etc/nginx/nginx.conf:ro
 ```

--- a/examples/nginx-contextpath/docker-compose.yml
+++ b/examples/nginx-contextpath/docker-compose.yml
@@ -5,7 +5,7 @@ services:
     image: plantuml/plantuml-server:jetty
     container_name: plantuml-server
     environment:
-      - TZ="Europe/Berlin"
+      - TZ=Europe/Berlin
       - BASE_URL=plantuml
 
   nginx:
@@ -14,6 +14,6 @@ services:
     ports:
       - "80:80"
     environment:
-      - TZ="Europe/Berlin"
+      - TZ=Europe/Berlin
     volumes:
       - ./nginx.conf:/etc/nginx/nginx.conf:ro

--- a/examples/nginx-simple/README.md
+++ b/examples/nginx-simple/README.md
@@ -64,7 +64,7 @@ services:
     image: plantuml/plantuml-server:jetty
     container_name: plantuml-server
     environment:
-      - TZ="Europe/Berlin"
+      - TZ=Europe/Berlin
 
   nginx:
     image: nginx:alpine
@@ -72,7 +72,7 @@ services:
     ports:
       - "80:80"
     environment:
-      - TZ="Europe/Berlin"
+      - TZ=Europe/Berlin
     volumes:
       - ./nginx.conf:/etc/nginx/nginx.conf:ro
 ```

--- a/examples/nginx-simple/docker-compose.yml
+++ b/examples/nginx-simple/docker-compose.yml
@@ -5,7 +5,7 @@ services:
     image: plantuml/plantuml-server:jetty
     container_name: plantuml-server
     environment:
-      - TZ="Europe/Berlin"
+      - TZ=Europe/Berlin
 
   nginx:
     image: nginx:alpine
@@ -13,6 +13,6 @@ services:
     ports:
       - "80:80"
     environment:
-      - TZ="Europe/Berlin"
+      - TZ=Europe/Berlin
     volumes:
       - ./nginx.conf:/etc/nginx/nginx.conf:ro

--- a/src/main/java/net/sourceforge/plantuml/servlet/PlantUmlServlet.java
+++ b/src/main/java/net/sourceforge/plantuml/servlet/PlantUmlServlet.java
@@ -255,16 +255,16 @@ public class PlantUmlServlet extends HttpServlet {
         request.setAttribute("showSocialButtons", Configuration.get("SHOW_SOCIAL_BUTTONS"));
         request.setAttribute("showGithubRibbon", Configuration.get("SHOW_GITHUB_RIBBON"));
         // URL base
-        final String hostpath = getHostpath(request);
-        request.setAttribute("hostpath", hostpath);
+        final String contextpath = request.getContextPath();
+        request.setAttribute("contextpath", contextpath);
         // image URLs
         final boolean hasImg = !text.isEmpty();
         request.setAttribute("hasImg", hasImg);
-        request.setAttribute("imgurl", hostpath + "/png/" + index + encoded);
-        request.setAttribute("svgurl", hostpath + "/svg/" + index + encoded);
-        request.setAttribute("pdfurl", hostpath + "/pdf/" + index + encoded);
-        request.setAttribute("txturl", hostpath + "/txt/" + index + encoded);
-        request.setAttribute("mapurl", hostpath + "/map/" + index + encoded);
+        request.setAttribute("imgurl", contextpath + "/png/" + index + encoded);
+        request.setAttribute("svgurl", contextpath + "/svg/" + index + encoded);
+        request.setAttribute("pdfurl", contextpath + "/pdf/" + index + encoded);
+        request.setAttribute("txturl", contextpath + "/txt/" + index + encoded);
+        request.setAttribute("mapurl", contextpath + "/map/" + index + encoded);
         // map for diagram source if necessary
         final boolean hasMap = PlantumlUtils.hasCMapData(text);
         request.setAttribute("hasMap", hasMap);
@@ -277,33 +277,6 @@ public class PlantUmlServlet extends HttpServlet {
             }
         }
         request.setAttribute("map", map);
-    }
-
-    /**
-     * Get hostpath (URL base) from request.
-     *
-     * @param request http request
-     *
-     * @return hostpath
-     */
-    private String getHostpath(final HttpServletRequest request) {
-        // port
-        String port = "";
-        if (
-            (request.getScheme() == "http" && request.getServerPort() != 80)
-            ||
-            (request.getScheme() == "https" && request.getServerPort() != 443)
-        ) {
-            port = ":" + request.getServerPort();
-        }
-        // scheme
-        String scheme = request.getScheme();
-        final String forwardedProto = request.getHeader("x-forwarded-proto");
-        if (forwardedProto != null && !forwardedProto.isEmpty()) {
-            scheme = forwardedProto;
-        }
-        // hostpath
-        return scheme + "://" + request.getServerName() + port + request.getContextPath();
     }
 
     /**

--- a/src/main/webapp/error.jsp
+++ b/src/main/webapp/error.jsp
@@ -1,20 +1,7 @@
 <%@ page isErrorPage="true" contentType="text/html; charset=utf-8" pageEncoding="utf-8" session="false" %>
 
 <%
-    String contextroot = request.getContextPath();
-    String port = "";
-    if (
-        (request.getScheme() == "http" && request.getServerPort() != 80)
-        ||
-        (request.getScheme() == "https" && request.getServerPort() != 443)
-    ) {
-        port = ":" + request.getServerPort();
-    }
-    String scheme = request.getScheme();
-    if (request.getHeader("x-forwarded-proto") != null && request.getHeader("x-forwarded-proto") != "") {
-        scheme = request.getHeader("x-forwarded-proto");
-    }
-    String hostpath = scheme + "://" + request.getServerName() + port + contextroot;
+    String contextpath = request.getContextPath();
 %>
 
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
@@ -24,9 +11,9 @@
     <meta http-equiv="expires" content="0" />
     <meta http-equiv="pragma" content="no-cache" />
     <meta http-equiv="cache-control" content="no-cache, must-revalidate" />
-    <link rel="stylesheet" href="<%= hostpath %>/plantuml.css" type="text/css"/>
-    <link rel="icon" href="<%= hostpath %>/favicon.ico" type="image/x-icon"/> 
-    <link rel="shortcut icon" href="<%= hostpath %>/favicon.ico" type="image/x-icon"/>
+    <link rel="stylesheet" href="<%= contextpath %>/plantuml.css" type="text/css"/>
+    <link rel="icon" href="<%= contextpath %>/favicon.ico" type="image/x-icon"/> 
+    <link rel="shortcut icon" href="<%= contextpath %>/favicon.ico" type="image/x-icon"/>
     <title>PlantUMLServer Error</title>
 </head>
 <body>

--- a/src/main/webapp/index.jsp
+++ b/src/main/webapp/index.jsp
@@ -7,7 +7,7 @@
     boolean showSocialButtons = (boolean)request.getAttribute("showSocialButtons");
     boolean showGithubRibbon = (boolean)request.getAttribute("showGithubRibbon");
     // URL base
-    String hostpath = request.getAttribute("hostpath").toString();
+    String contextpath = request.getAttribute("contextpath").toString();
     // image URLs
     boolean hasImg = (boolean)request.getAttribute("hasImg");
     String imgurl = request.getAttribute("imgurl").toString();
@@ -27,20 +27,26 @@
     <meta http-equiv="expires" content="0" />
     <meta http-equiv="pragma" content="no-cache" />
     <meta http-equiv="cache-control" content="no-cache, must-revalidate" />
-    <link rel="icon" href="<%= hostpath %>/favicon.ico" type="image/x-icon"/> 
-    <link rel="shortcut icon" href="<%= hostpath %>/favicon.ico" type="image/x-icon"/>
-    <link rel="stylesheet" href="<%= hostpath %>/plantuml.css" />
-    <link rel="stylesheet" href="<%= hostpath %>/webjars/codemirror/5.63.0/lib/codemirror.css" />
-    <script src="<%= hostpath %>/webjars/codemirror/5.63.0/lib/codemirror.js"></script>
+    <link rel="icon" href="<%= contextpath %>/favicon.ico" type="image/x-icon"/> 
+    <link rel="shortcut icon" href="<%= contextpath %>/favicon.ico" type="image/x-icon"/>
+    <link rel="stylesheet" href="<%= contextpath %>/plantuml.css" />
+    <link rel="stylesheet" href="<%= contextpath %>/webjars/codemirror/5.63.0/lib/codemirror.css" />
+    <script src="<%= contextpath %>/webjars/codemirror/5.63.0/lib/codemirror.js"></script>
     <script>
         window.onload = function() {
+            // load CodeMirror
             document.myCodeMirror = CodeMirror.fromTextArea(
                 document.getElementById("text"), 
                 { lineNumbers: true,
                   extraKeys: {Tab: false, "Shift-Tab": false} 
                 }
             );
-            };
+            // resolve relative path inside url input once
+            const url = document.getElementById("url");
+            if (!url.value.startsWith("http")) {
+                url.value = window.location.origin + url.value;
+            }
+        };
     </script>
     <title>PlantUMLServer</title>
 </head>
@@ -58,7 +64,7 @@
     </div>
     <div id="content">
         <%-- CONTENT --%>
-        <form method="post" accept-charset="utf-8"  action="<%= hostpath %>/form">
+        <form method="post" accept-charset="utf-8"  action="<%= contextpath %>/form">
             <p> <label for="text">UML Editor Content</label>
                 <textarea id="text" name="text" cols="120" rows="10"><%= net.sourceforge.plantuml.servlet.PlantUmlServlet.stringToHTMLString(decoded) %></textarea>
                 <input type="submit" value="Submit" title="Submit Code and generate diagram"/>&nbsp;
@@ -67,7 +73,7 @@
         </form>
         <hr/>
         <p>You can enter here a previously generated URL:</p>
-        <form method="post" action="<%= hostpath %>/form">
+        <form method="post" action="<%= contextpath %>/form">
             <p> <label for="url">previously generated URL</label>
                 <input id="url" name="url" type="text" size="150" value="<%= imgurl %>" />
                 <br/>
@@ -88,8 +94,12 @@
                 <%@ include file="resource/socialbuttons2.jspf" %>
             <% } %>
             <p id="diagram">
-                <img src="<%= imgurl %>" alt="PlantUML diagram" />
-                <%= map %>
+                <% if (!hasMap) { %>
+                    <img src="<%= imgurl %>" alt="PlantUML diagram" />
+                <% } else { %>
+                    <img src="<%= imgurl %>" alt="PlantUML diagram" usemap="#plantuml_map" />
+                    <%= map %>
+                <% } %>
             </p>
         <% } %>
     </div>


### PR DESCRIPTION
Switch from absolute paths (`hostpath`) to relative paths (`contextpath`).

Unfortunately, for the URL input JavaScript is necessary to resolve the relative URL.
Alternatively, we let this part untouched an use `hostpath`. But in this case it would be inconsistent. (And the same issues would still remain.)
@ctn maybe you want to review this?

Also see Issue #205 and #207.

This also improves the nginx example docker-compose.yml files and fixes the usage of the diagram map. (`usemap="#plantuml_map"` inside the `img` tag was missing. Now hovering and clicking the link in the diagram is possible.)

@arnaudroques these changes needs further considerations, review and testing.