### PR TITLE
Added support for arm64

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -128,7 +128,7 @@ jobs:
             latest=false
             prefix=
             suffix=
-          images: plantuml/plantuml-server
+          images: nikolaidamm/plantuml-server
           tags: |
             type=semver,pattern=tomcat-{{raw}}
             type=raw,value=tomcat
@@ -141,7 +141,7 @@ jobs:
             latest=true
             prefix=
             suffix=
-          images: plantuml/plantuml-server
+          images: nikolaidamm/plantuml-server
           tags: |
             type=semver,pattern={{raw}}
             type=semver,pattern=jetty-{{raw}}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -128,7 +128,7 @@ jobs:
             latest=false
             prefix=
             suffix=
-          images: nikolaidamm/plantuml-server
+          images: plantuml/plantuml-server
           tags: |
             type=semver,pattern=tomcat-{{raw}}
             type=raw,value=tomcat
@@ -141,7 +141,7 @@ jobs:
             latest=true
             prefix=
             suffix=
-          images: nikolaidamm/plantuml-server
+          images: plantuml/plantuml-server
           tags: |
             type=semver,pattern={{raw}}
             type=semver,pattern=jetty-{{raw}}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -176,7 +176,7 @@ jobs:
         with:
           context: .
           file: ./Dockerfile.jetty
-          platforms: linux/amd64
+          platforms: linux/amd64, linux/arm64
           push: true
           tags: ${{ steps.docker_meta_jetty.outputs.tags }}
           labels: ${{ steps.docker_meta_jetty.outputs.labels }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -165,7 +165,7 @@ jobs:
         with:
           context: .
           file: ./Dockerfile.tomcat
-          platforms: linux/amd64
+          platforms: linux/amd64, linux/arm64
           push: true
           tags: ${{ steps.docker_meta_tomcat.outputs.tags }}
           labels: ${{ steps.docker_meta_tomcat.outputs.labels }}


### PR DESCRIPTION
closes #158, closes #113 
I tested that this worked on my home cluster. 

I used the Jetty image behind a reverse proxy and built my .puml files with VScode pointing to the server.

Could you please add official support, as this is an easy fix?

EDIT: Untill then this image works for arm64: `devantler/plantuml-server:jetty`