### PR TITLE
Remove obsolete docker build instruction

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,9 +132,7 @@ You can set all  the following variables:
 ## Alternate: How to build your docker image
 
 This method uses maven to run the application. That requires internet connectivity.
-So, you can use following command to create a self-contained docker image that will "just-work".
-
-*Note: Generate the WAR (instructions further below) prior to running "docker build"*
+So, you can use following command to create a self-contained docker image that will "just work".
 
 ```sh
 docker image build -f Dockerfile.jetty -t plantuml-server:local .


### PR DESCRIPTION
The docker build instructions state the `.war` must be built manually beforehand.
Both Dockerfiles also build the war as part of a multi stage build, so I guess that comment is obsolete.