### PR TITLE
Allow specifying a PlantUML configuration file

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,9 @@ You can set all  the following variables:
 * `BASE_URL`
   * PlantUML Base URL path
   * Default value: `ROOT`
+* `PLANTUML_CONFIG_FILE`
+  * Local path to a PlantUML configuration file (identical to the `-config` flag on the CLI)
+  * Default value: `null`
 * `PLANTUML_LIMIT_SIZE`
   * Limits image width and height
   * Default value: `4096`


### PR DESCRIPTION
This pull requests introduces a `PLANTUML_CONFIG_FILE` environment variable that allows one to specify a path to a local PlantUML configuration file that should be applied to all diagrams. This allows server administrators to change the default theme, set default styling options, etc. It uses the same functionality exposed by the `-config` flag of the PlantUML CLI.

Implementation details:

- If the `PLANTUML_CONFIG_FILE` env variable is set, the configuration is read once and stored in static variable.
- If the `PLANTUML_CONFIG_FILE` env variable is set and the generated diagram throws an exception, the diagram is regenerated without the configuration file before being returned. This is mainly done to prevent end users from seeing exceptions caused by the configuration file.