### PR TITLE
feat: support deep base URLs

### DIFF
--- a/Dockerfile.jetty
+++ b/Dockerfile.jetty
@@ -24,16 +24,16 @@ RUN apt-get update && \
     rm -rf /var/lib/apt/lists/* && \
     /generate-jetty-start.sh
 
-COPY docker-entrypoint.sh /entrypoint.sh
+COPY docker-entrypoint.jetty.sh /entrypoint.sh
 RUN chmod +x /entrypoint.sh
 
 USER jetty
 
-ENV BASE_URL=ROOT \
-    WEBAPP_PATH=$JETTY_BASE/webapps
+ENV WEBAPP_PATH=$JETTY_BASE/webapps
 RUN rm -rf $WEBAPP_PATH && \
     mkdir -p $WEBAPP_PATH
-COPY --from=builder /app/target/plantuml.war $WEBAPP_PATH/ROOT.war
+COPY --from=builder /app/target/plantuml.war /plantuml.war
+COPY ROOT.jetty.xml $WEBAPP_PATH/ROOT.xml
 
 ENTRYPOINT ["/entrypoint.sh"]
 # Openshift https://docs.openshift.com/container-platform/4.9/openshift_images/create-images.html#images-create-guide-openshift_create-images

--- a/Dockerfile.tomcat
+++ b/Dockerfile.tomcat
@@ -17,14 +17,13 @@ RUN apt-get update && \
         && \
     rm -rf /var/lib/apt/lists/*
 
-COPY docker-entrypoint.sh /entrypoint.sh
+COPY docker-entrypoint.tomcat.sh /entrypoint.sh
 RUN chmod +x /entrypoint.sh
 
-ENV BASE_URL=ROOT \
-    WEBAPP_PATH=$CATALINA_HOME/webapps
+ENV WEBAPP_PATH=$CATALINA_HOME/webapps
 RUN rm -rf $WEBAPP_PATH && \
     mkdir -p $WEBAPP_PATH
-COPY --from=builder /app/target/plantuml.war $WEBAPP_PATH/ROOT.war
+COPY --from=builder /app/target/plantuml.war /plantuml.war
 
 ENTRYPOINT ["/entrypoint.sh"]
 CMD ["catalina.sh", "run"]

--- a/ROOT.jetty.xml
+++ b/ROOT.jetty.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://www.eclipse.org/jetty/configure_10_0.dtd">
+
+<Configure class="org.eclipse.jetty.webapp.WebAppContext">
+  <Set name="contextPath">
+    <Env name="CONTEXT_PATH" />
+  </Set>
+  <Set name="war">/plantuml.war</Set>
+</Configure>

--- a/docker-entrypoint.jetty.sh
+++ b/docker-entrypoint.jetty.sh
@@ -3,11 +3,8 @@
 # cspell:enableCompoundWords
 ###########################################################
 
-# use environment variables
-if [ "$BASE_URL" != "ROOT" ]; then
-    mkdir -p "$(dirname "$WEBAPP_PATH/$BASE_URL")"
-    mv "$WEBAPP_PATH/ROOT.war" "$WEBAPP_PATH/$BASE_URL.war"
-fi
+# ensure context path starts with a slash
+export CONTEXT_PATH="/${BASE_URL#'/'}"
 
 # base image entrypoint
 if [ -x /docker-entrypoint.sh ]; then

--- a/docker-entrypoint.tomcat.sh
+++ b/docker-entrypoint.tomcat.sh
@@ -1,0 +1,18 @@
+#!/bin/sh
+# cspell:words mkdir
+# cspell:enableCompoundWords
+###########################################################
+
+# choose war file name so that context path is correctly set based on BASE_URL,
+# following the rules from https://tomcat.apache.org/tomcat-9.0-doc/config/context.html#Naming,
+# specifically remove leading and trailing slashes and replace the remaining ones by hashes.
+export FILE_NAME="$(echo "$BASE_URL" | sed -e 's:^/::' -e 's:/$::' -e 's:/:#:g')"
+export FILE_PATH="$WEBAPP_PATH/$FILE_NAME.war"
+mv /plantuml.war "$FILE_PATH"
+
+# base image entrypoint
+if [ -x /docker-entrypoint.sh ]; then
+    /docker-entrypoint.sh "$@"
+else
+    exec "$@"
+fi


### PR DESCRIPTION
This MR adds support for passing deep base URLs like `/nested/path`. 

For Jetty I had to move away from the current convention based approach because that only support simple URLs with a single path element (see [deployment rules](https://www.eclipse.org/jetty/documentation/jetty-11/operations-guide/index.html#og-deploy-rules)). The best way to implement this in a generic way cases seems to be the config file approach. That also supports environment variables out of the box and therefore reduces complexity in the entrypoint script and in the Dockerfile.

For Tomcat it's a bit easier because it supports such URLs out of the box via special file name conventions, see https://tomcat.apache.org/tomcat-9.0-doc/config/context.html#Naming.

I made multiple manual tests to verify things are working as expected:

- ✅ `docker build . -f Dockerfile.tomcat -t plantuml-server && docker run -p 8080:8080 -it -e BASE_URL=foo/ plantuml-server`
- ✅ `docker build . -f Dockerfile.tomcat -t plantuml-server && docker run -p 8080:8080 -it -e BASE_URL=foo/bar plantuml-server`
- ✅ `docker build . -f Dockerfile.tomcat -t plantuml-server && docker run -p 8080:8080 -it plantuml-server `
- ✅ `docker build . -f Dockerfile.tomcat -t plantuml-server && docker run -p 8080:8080 -it -e BASE_URL=/foo plantuml-server`
- ✅ `docker build . -f Dockerfile.jetty -t plantuml-server && docker run -p 8080:8080 -it -e BASE_URL=foo/ plantuml-server`
- ✅ `docker build . -f Dockerfile.jetty -t plantuml-server && docker run -p 8080:8080 -it -e BASE_URL=foo/bar plantuml-server`
- ✅ `docker build . -f Dockerfile.jetty -t plantuml-server && docker run -p 8080:8080 -it plantuml-server`
- ✅ `docker build . -f Dockerfile.jetty -t plantuml-server && docker run -p 8080:8080 -it -e BASE_URL=/foo plantuml-server`

🛠 with ❤️ by [Siemens](https://opensource.siemens.com/)
