### PR TITLE
Add explicit VOLUME instruction for jetty image

### DIFF
--- a/Dockerfile.jetty
+++ b/Dockerfile.jetty
@@ -41,3 +41,5 @@ USER root
 RUN chgrp -R 0 $JETTY_BASE &&   chmod -R g=u $JETTY_BASE
 RUN chgrp -R 0 /tmp &&   chmod -R g=u /tmp
 USER jetty
+
+VOLUME ["/tmp/jetty"]


### PR DESCRIPTION
Set a mount point for read-only root file system configurations. Without the explicit mount point definition in the image, we were facing issues on Amazon ECS, because the directory got mounted with different ownership (root) and mode (0755).

For reference please see also:
https://docs.aws.amazon.com/AmazonECS/latest/developerguide/bind-mounts.html#bind-mount-considerations