### PR TITLE
Fix workflows deprecated warnings

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,11 +9,11 @@ jobs:
   build-jdk11:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-java@v2
+      - uses: actions/setup-java@v3
         with:
           distribution: "zulu"
           java-version: 11
@@ -22,7 +22,7 @@ jobs:
 
       - name: get tag name
         id: version
-        run: echo ::set-output name=VERSION::${GITHUB_REF#refs/*/}
+        run: echo "VERSION=${GITHUB_REF#refs/*/}" >> $GITHUB_OUTPUT
 
       - name: build with maven
         run: mvn --batch-mode --define java.net.useSystemProxies=true package
@@ -37,7 +37,7 @@ jobs:
         run: cp target/plantuml.war target/plantuml-jsp-${{ steps.version.outputs.VERSION }}.war
 
       - name: temporarily save generated war files
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: war-jre11
           path: target/plantuml*-${{ steps.version.outputs.VERSION }}.war
@@ -45,11 +45,11 @@ jobs:
   build-jdk8:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-java@v2
+      - uses: actions/setup-java@v3
         with:
           distribution: "zulu"
           java-version: 8
@@ -58,7 +58,7 @@ jobs:
 
       - name: get tag name
         id: version
-        run: echo ::set-output name=VERSION::${GITHUB_REF#refs/*/}
+        run: echo "VERSION=${GITHUB_REF#refs/*/}" >> $GITHUB_OUTPUT
 
       - name: Remove test code (not java 8 compatible)
         run: rm -rf src/test
@@ -76,7 +76,7 @@ jobs:
         run: cp target/plantuml.war target/plantuml-jre8-jsp-${{ steps.version.outputs.VERSION }}.war
 
       - name: temporarily save generated war files
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: war-jre8
           path: target/plantuml*-${{ steps.version.outputs.VERSION }}.war
@@ -88,13 +88,13 @@ jobs:
       - build-jdk8
     steps:
       - name: retrieve generated war files (jre8)
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: war-jre8
           path: artifacts
 
       - name: retrieve generated war files (jre11)
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: war-jre11
           path: artifacts
@@ -116,7 +116,7 @@ jobs:
     needs:
       - publish-releases
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
 
@@ -186,11 +186,11 @@ jobs:
     needs:
       - publish-releases
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-java@v2
+      - uses: actions/setup-java@v3
         with:
           distribution: "zulu"
           java-version: 11

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,11 +8,11 @@ jobs:
   test-java-8-war-generation:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-java@v2
+      - uses: actions/setup-java@v3
         with:
           distribution: "zulu"
           java-version: 8
@@ -29,7 +29,7 @@ jobs:
         run: mvn --batch-mode -f pom.jdk8.xml -D java.net.useSystemProxies=true clean package
 
       - name: temporarily save generated files
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: war-jre8
           path: target/plantuml.war
@@ -42,17 +42,17 @@ jobs:
       matrix:
         java-version: [ 11, 17 ]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
 
       - name: retrieve generated files (jre8)
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: war-jre8
           path: artifacts
 
-      - uses: actions/setup-java@v2
+      - uses: actions/setup-java@v3
         with:
           distribution: "zulu"
           java-version: ${{ matrix.java-version }}
@@ -77,11 +77,11 @@ jobs:
       matrix:
         java-version: [ 11, 17 ]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-java@v2
+      - uses: actions/setup-java@v3
         with:
           distribution: "zulu"
           java-version: ${{ matrix.java-version }}
@@ -119,11 +119,11 @@ jobs:
       matrix:
         java-version: [ 11, 17 ]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-java@v2
+      - uses: actions/setup-java@v3
         with:
           distribution: "zulu"
           java-version: ${{ matrix.java-version }}
@@ -140,11 +140,11 @@ jobs:
       matrix:
         java-version: [ 11, 17 ]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-java@v2
+      - uses: actions/setup-java@v3
         with:
           distribution: "zulu"
           java-version: ${{ matrix.java-version }}
@@ -170,11 +170,11 @@ jobs:
       matrix:
         java-version: [ 11, 17 ]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-java@v2
+      - uses: actions/setup-java@v3
         with:
           distribution: "zulu"
           java-version: ${{ matrix.java-version }}
@@ -200,11 +200,11 @@ jobs:
       matrix:
         java-version: [ 11, 17 ]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-java@v2
+      - uses: actions/setup-java@v3
         with:
           distribution: "zulu"
           java-version: ${{ matrix.java-version }}
@@ -232,11 +232,11 @@ jobs:
       matrix:
         java-version: [ 11, 17 ]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-java@v2
+      - uses: actions/setup-java@v3
         with:
           distribution: "zulu"
           java-version: ${{ matrix.java-version }}


### PR DESCRIPTION
Currently the workflow actions throw 90 deprecated warnings during the testing phase. This PR should fix them.

![image](https://user-images.githubusercontent.com/5962361/226617606-01aad9b6-62a4-440f-a852-fcf38c9a8627.png)

----

- The `set-output` command is deprecated and will be disabled soon. Please upgrade to using Environment Files. For more information see: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/
- Node.js 12 actions are deprecated. Please update the following actions to use Node.js 16: actions/checkout@v2, actions/setup-java@v2, actions/upload-artifact@v2, actions/download-artifact@v2. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/