### PR TITLE
refactor: split domain code from servlet code

### DIFF
--- a/pom.jdk8.xml
+++ b/pom.jdk8.xml
@@ -64,6 +64,7 @@
     <jetty-annotations.version>${jetty.version}</jetty-annotations.version>
     <glassfish-jstl.version>${jetty.version}</glassfish-jstl.version>
     <batik-all.version>1.14</batik-all.version>
+    <lombok.version>1.18.26</lombok.version>
     <!-- jlatexmath -->
     <jlatexmath.version>1.0.7</jlatexmath.version>
     <jlatexmath-font-greek.version>${jlatexmath.version}</jlatexmath-font-greek.version>
@@ -165,6 +166,12 @@
       <groupId>org.scilab.forge</groupId>
       <artifactId>jlatexmath-font-cyrillic</artifactId>
       <version>${jlatexmath-font-cyrillic.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.projectlombok</groupId>
+      <artifactId>lombok</artifactId>
+      <version>${lombok.version}</version>
+      <scope>provided</scope>
     </dependency>
 
     <!-- Testing -->

--- a/pom.xml
+++ b/pom.xml
@@ -96,6 +96,7 @@
     <jetty-maven-plugin.version>${jetty.version}</jetty-maven-plugin.version>
     <duplicate-finder-maven-plugin.version>1.5.0</duplicate-finder-maven-plugin.version>
     <maven-javadoc-plugin.version>3.3.1</maven-javadoc-plugin.version>
+    <lombok.version>1.18.26</lombok.version>
   </properties>
 
   <dependencies>
@@ -173,6 +174,12 @@
       <version>2.7</version>
       <type>pom</type>
     </dependency>
+      <dependency>
+          <groupId>org.projectlombok</groupId>
+          <artifactId>lombok</artifactId>
+          <version>${lombok.version}</version>
+          <scope>provided</scope>
+      </dependency>
   </dependencies>
 
   <build>

--- a/pom.xml
+++ b/pom.xml
@@ -479,6 +479,11 @@
           </reportSet>
         </reportSets>
       </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-report-plugin</artifactId>
+        <version>${maven-surefire-plugin.version}</version>
+      </plugin>
     </plugins>
   </reporting>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -64,6 +64,7 @@
     <jetty-annotations.version>${jetty.version}</jetty-annotations.version>
     <glassfish-jstl.version>${jetty.version}</glassfish-jstl.version>
     <batik-all.version>1.14</batik-all.version>
+    <lombok.version>1.18.26</lombok.version>
     <!-- jlatexmath -->
     <jlatexmath.version>1.0.7</jlatexmath.version>
     <jlatexmath-font-greek.version>${jlatexmath.version}</jlatexmath-font-greek.version>
@@ -96,7 +97,6 @@
     <jetty-maven-plugin.version>${jetty.version}</jetty-maven-plugin.version>
     <duplicate-finder-maven-plugin.version>1.5.0</duplicate-finder-maven-plugin.version>
     <maven-javadoc-plugin.version>3.3.1</maven-javadoc-plugin.version>
-    <lombok.version>1.18.26</lombok.version>
   </properties>
 
   <dependencies>
@@ -174,12 +174,12 @@
       <version>2.7</version>
       <type>pom</type>
     </dependency>
-      <dependency>
-          <groupId>org.projectlombok</groupId>
-          <artifactId>lombok</artifactId>
-          <version>${lombok.version}</version>
-          <scope>provided</scope>
-      </dependency>
+    <dependency>
+        <groupId>org.projectlombok</groupId>
+        <artifactId>lombok</artifactId>
+        <version>${lombok.version}</version>
+        <scope>provided</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/src/main/java/net/sourceforge/plantuml/servlet/PlantUmlRequestAdapter.java
+++ b/src/main/java/net/sourceforge/plantuml/servlet/PlantUmlRequestAdapter.java
@@ -1,0 +1,79 @@
+package net.sourceforge.plantuml.servlet;
+
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.Data;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+
+import java.util.Optional;
+
+/**
+ * Typesafe accessors to request parameters.
+ */
+@Data
+@RequiredArgsConstructor
+public final class PlantUmlRequestAdapter {
+    private static final String TEXT = "text";
+    public static final String URL = "url";
+    public static final String METADATA = "metadata";
+
+    @NonNull
+    private final HttpServletRequest request;
+
+    /**
+     * @deprecated Use {@link #optionalParameter(String)} instead.
+     */
+    @Deprecated
+    public String getParameter(String name) {
+        return request.getParameter(name);
+    }
+
+    private Optional<String> optionalParameter(String name) {
+        return Optional.ofNullable(request.getParameter(name));
+    }
+
+    private Optional<String> optionalNonEmptyParameter(String name) {
+        return optionalParameter(name).map(String::trim).filter(v -> !v.isEmpty());
+    }
+
+    public Optional<String> getMetadata() {
+        return optionalParameter(METADATA);
+    }
+
+    /**
+     * @deprecated use {@link #getCleanedText()} instead;
+     */
+    @Deprecated
+    public Optional<String> getText() {
+        return optionalParameter(TEXT);
+    }
+
+    public Optional<String> getCleanedText() {
+        return optionalNonEmptyParameter(TEXT);
+    }
+
+    /**
+     * @deprecated use {@link #getCleanedUrl()} instead;
+     */
+    @Deprecated
+    public Optional<String> getUrl() {
+        return optionalParameter(URL);
+    }
+
+    public Optional<String> getCleanedUrl() {
+        return optionalNonEmptyParameter(URL);
+    }
+
+    public Optional<String> getRequestURI() {
+        return Optional.of(request.getRequestURI());
+    }
+
+    /**
+     * Use (or add) methods on this class to hide the request.
+     * This method will be removed after refactoring.
+     */
+    @Deprecated
+    public HttpServletRequest getRequest() {
+        return request;
+    }
+}

--- a/src/main/java/net/sourceforge/plantuml/servlet/PlantUmlUrlProcessor.java
+++ b/src/main/java/net/sourceforge/plantuml/servlet/PlantUmlUrlProcessor.java
@@ -1,0 +1,18 @@
+package net.sourceforge.plantuml.servlet;
+
+import lombok.Data;
+import lombok.RequiredArgsConstructor;
+
+@Data
+@RequiredArgsConstructor
+public final class PlantUmlUrlProcessor {
+    private final String requestUri;
+
+    public PlantUmlUrlProcessor(PlantUmlRequestAdapter adapter) {
+        this(adapter.getRequest().getRequestURI());
+    }
+
+    public boolean isUml() {
+        return requestUri.contains("/uml/") && !requestUri.endsWith("/uml/");
+    }
+}

--- a/src/main/java/net/sourceforge/plantuml/servlet/utility/Assertions.java
+++ b/src/main/java/net/sourceforge/plantuml/servlet/utility/Assertions.java
@@ -1,0 +1,19 @@
+package net.sourceforge.plantuml.servlet.utility;
+
+import java.util.Optional;
+
+public final class Assertions {
+    private Assertions() {
+    }
+
+    @SuppressWarnings("OptionalUsedAsFieldOrParameterType")
+    public static void assertTrimmedIfPresent(Optional<String> optional, String name) throws AssertionError {
+        if (optional.isPresent()) {
+            String value = optional.get();
+            if (!value.equals(value.trim())) {
+                String message = String.format("%s >%s< should have been trimmed", name, value);
+                throw new AssertionError(message);
+            }
+        }
+    }
+}

--- a/src/main/java/net/sourceforge/plantuml/servlet/utility/HtmlUtils.java
+++ b/src/main/java/net/sourceforge/plantuml/servlet/utility/HtmlUtils.java
@@ -1,0 +1,43 @@
+package net.sourceforge.plantuml.servlet.utility;
+
+public final class HtmlUtils {
+    private HtmlUtils() {
+    }
+
+    public static String htmlEscape(String string) {
+        final StringBuffer sb = new StringBuffer(string.length());
+        // true if last char was blank
+        final int length = string.length();
+        for (int offset = 0; offset < length;) {
+            final int c = string.codePointAt(offset);
+            if (c == ' ') {
+                sb.append(' ');
+            } else if (c == '"') {
+                sb.append("&quot;");
+            } else if (c == '&') {
+                sb.append("&amp;");
+            } else if (c == '<') {
+                sb.append("&lt;");
+            } else if (c == '>') {
+                sb.append("&gt;");
+            } else if (c == '\r') {
+                sb.append("\r");
+            } else if (c == '\n') {
+                sb.append("\n");
+            } else {
+                int ci = 0xffffff & c;
+                if (ci < 160) {
+                    // nothing special only 7 Bit
+                    sb.append((char) c);
+                } else {
+                    // Not 7 Bit use the unicode system
+                    sb.append("&#");
+                    sb.append(ci);
+                    sb.append(';');
+                }
+            }
+            offset += Character.charCount(c);
+        }
+        return sb.toString();
+    }
+}


### PR DESCRIPTION
First step on PlantUmlServlet.

The main goal is to spliut the code depnding on the Servlet API from the rest of the code. This way, it will be possible to use an other adpter layer like a rest api for example.

> Note: I will add more commits.
