### PR TITLE
fix: use up-to-date graphviz version in tomcat image

### DIFF
--- a/Dockerfile.jetty
+++ b/Dockerfile.jetty
@@ -24,6 +24,7 @@ RUN apt-get update && \
     rm -rf /var/lib/apt/lists/* && \
     /generate-jetty-start.sh
 
+# Build Graphviz from source because there are no binary distributions for recent versions
 ARG GRAPHVIZ_VERSION=7.1.0
 ARG GRAPHVIZ_BUILD_DIR=/tmp/graphiz-build
 RUN apt-get update && \
@@ -42,8 +43,6 @@ RUN apt-get update && \
     apt-get remove -y curl build-essential && \
     rm -rf /var/lib/apt/lists/* && \
     rm -rf $GRAPHVIZ_BUILD_DIR
-
-RUN dot -V
 
 COPY docker-entrypoint.jetty.sh /entrypoint.sh
 RUN chmod +x /entrypoint.sh

--- a/Dockerfile.tomcat
+++ b/Dockerfile.tomcat
@@ -13,9 +13,29 @@ FROM tomcat:10-jdk11-openjdk-slim
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
         fonts-noto-cjk \
-        graphviz \
+        libgd3 \
         && \
     rm -rf /var/lib/apt/lists/*
+
+# Build Graphviz from source because there are no binary distributions for recent versions
+ARG GRAPHVIZ_VERSION=7.1.0
+ARG GRAPHVIZ_BUILD_DIR=/tmp/graphiz-build
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+        curl \
+        build-essential \
+        && \
+    mkdir -p $GRAPHVIZ_BUILD_DIR && \
+    cd $GRAPHVIZ_BUILD_DIR && \
+    curl -o graphviz.tar.gz https://gitlab.com/api/v4/projects/4207231/packages/generic/graphviz-releases/${GRAPHVIZ_VERSION}/graphviz-${GRAPHVIZ_VERSION}.tar.gz && \
+    tar -xzf graphviz.tar.gz && \
+    cd graphviz-$GRAPHVIZ_VERSION && \
+    ./configure && \
+    make && \
+    make install && \
+    apt-get remove -y curl build-essential && \
+    rm -rf /var/lib/apt/lists/* && \
+    rm -rf $GRAPHVIZ_BUILD_DIR
 
 COPY docker-entrypoint.tomcat.sh /entrypoint.sh
 RUN chmod +x /entrypoint.sh


### PR DESCRIPTION
The same changes as in #267 for the Tomcat image.

🛠 with ❤ at [Siemens](https://opensource.siemens.com/)