### PR TITLE
fix: add missing build dependency for graphviz

### DIFF
--- a/Dockerfile.jetty
+++ b/Dockerfile.jetty
@@ -25,12 +25,13 @@ RUN apt-get update && \
     /generate-jetty-start.sh
 
 # Build Graphviz from source because there are no binary distributions for recent versions
-ARG GRAPHVIZ_VERSION=7.1.0
+ARG GRAPHVIZ_VERSION=8.0.2
 ARG GRAPHVIZ_BUILD_DIR=/tmp/graphiz-build
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
         curl \
         build-essential \
+        libexpat1-dev \
         && \
     mkdir -p $GRAPHVIZ_BUILD_DIR && \
     cd $GRAPHVIZ_BUILD_DIR && \

--- a/Dockerfile.tomcat
+++ b/Dockerfile.tomcat
@@ -18,12 +18,13 @@ RUN apt-get update && \
     rm -rf /var/lib/apt/lists/*
 
 # Build Graphviz from source because there are no binary distributions for recent versions
-ARG GRAPHVIZ_VERSION=7.1.0
+ARG GRAPHVIZ_VERSION=8.0.2
 ARG GRAPHVIZ_BUILD_DIR=/tmp/graphiz-build
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
         curl \
         build-essential \
+        libexpat1-dev \
         && \
     mkdir -p $GRAPHVIZ_BUILD_DIR && \
     cd $GRAPHVIZ_BUILD_DIR && \


### PR DESCRIPTION
This adds the missing dependency as suggested in https://github.com/plantuml/plantuml-server/issues/270#issuecomment-1503083638 and upgrades to the latest GraphViz release.

With this the C4 diagrams are properly rendered again.