### PR TITLE
Update dependencies (security updates)

### DIFF
--- a/Dockerfile.jetty
+++ b/Dockerfile.jetty
@@ -8,7 +8,7 @@ RUN mvn --batch-mode --define java.net.useSystemProxies=true package
 
 ########################################################################################
 
-FROM jetty:11.0.7-jre11-slim
+FROM jetty:11.0.15-jre11-slim
 
 # Proxy and OldProxy need empty path segments support in URIs
 # Hence: allow AMBIGUOUS_EMPTY_SEGMENT
@@ -65,7 +65,7 @@ COPY ROOT.jetty.xml $WEBAPP_PATH/ROOT.xml
 
 ENTRYPOINT ["/entrypoint.sh"]
 # Openshift https://docs.openshift.com/container-platform/4.9/openshift_images/create-images.html#images-create-guide-openshift_create-images
-USER root 
+USER root
 RUN chgrp -R 0 $JETTY_BASE &&   chmod -R g=u $JETTY_BASE
 RUN chgrp -R 0 /tmp &&   chmod -R g=u /tmp
 USER jetty

--- a/Dockerfile.jetty-alpine
+++ b/Dockerfile.jetty-alpine
@@ -1,4 +1,4 @@
-FROM maven:3-eclipse-temurin-11 AS builder
+FROM maven:3-eclipse-temurin-11-alpine AS builder
 
 COPY pom.xml /app/
 COPY src/main /app/src/main/
@@ -8,7 +8,7 @@ RUN mvn --batch-mode --define java.net.useSystemProxies=true package
 
 ########################################################################################
 
-FROM jetty:11.0.15-jre11
+FROM jetty:11.0.15-jre11-alpine-eclipse-temurin
 
 # Proxy and OldProxy need empty path segments support in URIs
 # Hence: allow AMBIGUOUS_EMPTY_SEGMENT
@@ -17,24 +17,21 @@ RUN sed -i 's/# jetty\.httpConfig\.uriCompliance=DEFAULT/jetty.httpConfig.uriCom
 
 USER root
 
-RUN apt-get update && \
-    apt-get install -y --no-install-recommends \
+RUN apk add --no-cache \
         curl \
-        fonts-noto-cjk \
-        libgd3 \
+        font-noto-cjk \
+        libgd \
         && \
-    rm -rf /var/lib/apt/lists/* && \
     /generate-jetty-start.sh
 
-# Build Graphviz from source because there are no binary distributions for recent versions
+#RUN apk add --no-cache graphviz
 ARG GRAPHVIZ_VERSION=8.0.2
 ARG GRAPHVIZ_BUILD_DIR=/tmp/graphiz-build
-RUN apt-get update && \
-    apt-get install -y --no-install-recommends \
-        build-essential \
-        libexpat1-dev \
-        libgd-dev \
-        zlib1g-dev \
+RUN apk add --no-cache \
+        g++ \
+        libexpat \
+        make \
+        zlib \
         && \
     mkdir -p $GRAPHVIZ_BUILD_DIR && \
     cd $GRAPHVIZ_BUILD_DIR && \
@@ -44,15 +41,12 @@ RUN apt-get update && \
     ./configure && \
     make && \
     make install && \
-    apt-get remove -y \
-        build-essential \
-        libexpat1-dev \
-        libgd-dev \
-        zlib1g-dev \
+    apk del --no-cache \
+        g++ \
+        libexpat \
+        make \
+        zlib \
         && \
-    apt-get autoremove -y && \
-    apt-get clean & \
-    rm -rf /var/lib/apt/lists/* && \
     rm -rf $GRAPHVIZ_BUILD_DIR
 
 COPY docker-entrypoint.jetty.sh /entrypoint.sh
@@ -68,8 +62,10 @@ COPY ROOT.jetty.xml $WEBAPP_PATH/ROOT.xml
 
 # Openshift https://docs.openshift.com/container-platform/4.9/openshift_images/create-images.html#images-create-guide-openshift_create-images
 USER root
-RUN chgrp -R 0 $JETTY_BASE &&   chmod -R g=u $JETTY_BASE
-RUN chgrp -R 0 /tmp &&   chmod -R g=u /tmp
+RUN chgrp -R 0 $JETTY_BASE && \
+    chmod -R g=u $JETTY_BASE
+RUN chgrp -R 0 /tmp && \
+    chmod -R g=u /tmp
 USER jetty
 
 ENTRYPOINT ["/entrypoint.sh"]

--- a/Dockerfile.tomcat
+++ b/Dockerfile.tomcat
@@ -1,4 +1,4 @@
-FROM maven:3-jdk-11-slim AS builder
+FROM maven:3-eclipse-temurin-11 AS builder
 
 COPY pom.xml /app/
 COPY src/main /app/src/main/
@@ -8,10 +8,11 @@ RUN mvn --batch-mode --define java.net.useSystemProxies=true -Dapache-jsp.scope=
 
 ########################################################################################
 
-FROM tomcat:10-jdk11-openjdk-slim
+FROM tomcat:10-jdk11
 
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
+        curl \
         fonts-noto-cjk \
         libgd3 \
         && \
@@ -22,7 +23,6 @@ ARG GRAPHVIZ_VERSION=8.0.2
 ARG GRAPHVIZ_BUILD_DIR=/tmp/graphiz-build
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
-        curl \
         build-essential \
         libexpat1-dev \
         libgd-dev \
@@ -42,6 +42,8 @@ RUN apt-get update && \
         libgd-dev \
         zlib1g-dev \
         && \
+    apt-get autoremove -y && \
+    apt-get clean & \
     rm -rf /var/lib/apt/lists/* && \
     rm -rf $GRAPHVIZ_BUILD_DIR
 
@@ -53,8 +55,8 @@ RUN rm -rf $WEBAPP_PATH && \
     mkdir -p $WEBAPP_PATH
 COPY --from=builder /app/target/plantuml.war /plantuml.war
 
+# Openshift https://docs.openshift.com/container-platform/4.9/openshift_images/create-images.html#images-create-guide-openshift_create-images
+RUN chgrp -R 0 $CATALINA_HOME &&  chmod -R g=u $CATALINA_HOME
+
 ENTRYPOINT ["/entrypoint.sh"]
 CMD ["catalina.sh", "run"]
-# Openshift https://docs.openshift.com/container-platform/4.9/openshift_images/create-images.html#images-create-guide-openshift_create-images
-USER root 
-RUN chgrp -R 0 $CATALINA_HOME &&  chmod -R g=u $CATALINA_HOME

--- a/pom.jdk8.xml
+++ b/pom.jdk8.xml
@@ -93,7 +93,7 @@
     <maven-site-plugin.version>3.12.1</maven-site-plugin.version>
     <maven-project-info-reports-plugin.version>3.4.3</maven-project-info-reports-plugin.version>
     <maven-checkstyle-plugin.version>3.2.2</maven-checkstyle-plugin.version>
-    <checkstyle.version>10.10.0</checkstyle.version>
+    <checkstyle.version>9.3</checkstyle.version><!-- no JDK8 support starting version 10.0.0 -->
 
     <!-- plugins -->
     <maven-eclipse-plugin.version>2.10</maven-eclipse-plugin.version>

--- a/pom.jdk8.xml
+++ b/pom.jdk8.xml
@@ -55,7 +55,7 @@
     <!-- main versions -->
     <plantuml.version>1.2023.6</plantuml.version>
     <!-- Please keep the jetty version identical with the docker image -->
-    <jetty.version>11.0.7</jetty.version>
+    <jetty.version>11.0.15</jetty.version>
     <monaco-editor.version>0.36.1</monaco-editor.version>
 
     <!-- dependencies -->
@@ -63,41 +63,44 @@
     <apache-jsp.version>${jetty.version}</apache-jsp.version>
     <jetty-annotations.version>${jetty.version}</jetty-annotations.version>
     <glassfish-jstl.version>${jetty.version}</glassfish-jstl.version>
-    <batik-all.version>1.14</batik-all.version>
     <!-- jlatexmath -->
     <jlatexmath.version>1.0.7</jlatexmath.version>
     <jlatexmath-font-greek.version>${jlatexmath.version}</jlatexmath-font-greek.version>
     <jlatexmath-font-cyrillic.version>${jlatexmath.version}</jlatexmath-font-cyrillic.version>
+    <!-- PDF -->
+    <batik-all.version>1.16</batik-all.version>
+    <fop.version>2.8</fop.version>
 
     <!-- Testing -->
-    <junit.version>4.13.2</junit.version>
-    <selenium.version>4.8.3</selenium.version>
+    <junit.version>5.9.3</junit.version>
+    <junit-suite.version>1.9.3</junit-suite.version>
+    <selenium.version>4.9.0</selenium.version>
     <selenium-webdrivermanager.version>5.3.2</selenium-webdrivermanager.version>
     <commons-io.version>2.11.0</commons-io.version>
     <jetty-server.version>${jetty.version}</jetty-server.version>
 
     <!-- build plugin management -->
     <!-- lock down plugins versions to avoid using Maven defaults -->
-    <maven-clean-plugin.version>3.1.0</maven-clean-plugin.version>
-    <maven-dependency-plugin.version>3.2.0</maven-dependency-plugin.version>
-    <maven-resources-plugin.version>3.2.0</maven-resources-plugin.version>
-    <maven-compiler-plugin.version>3.8.1</maven-compiler-plugin.version>
-    <versions-maven-plugin.version>2.8.1</versions-maven-plugin.version>
-    <maven-surefire-plugin.version>2.22.2</maven-surefire-plugin.version>
+    <maven-clean-plugin.version>3.2.0</maven-clean-plugin.version>
+    <maven-dependency-plugin.version>3.5.0</maven-dependency-plugin.version>
+    <maven-resources-plugin.version>3.3.1</maven-resources-plugin.version>
+    <maven-compiler-plugin.version>3.11.0</maven-compiler-plugin.version>
+    <versions-maven-plugin.version>2.15.0</versions-maven-plugin.version>
+    <maven-surefire-plugin.version>3.0.0</maven-surefire-plugin.version>
     <maven-war-plugin.version>3.3.2</maven-war-plugin.version>
-    <maven-install-plugin.version>2.5.2</maven-install-plugin.version>
-    <maven-deploy-plugin.version>2.8.2</maven-deploy-plugin.version>
-    <maven-site-plugin.version>3.9.1</maven-site-plugin.version>
-    <maven-project-info-reports-plugin.version>3.1.2</maven-project-info-reports-plugin.version>
-    <maven-checkstyle-plugin.version>3.1.2</maven-checkstyle-plugin.version>
-    <checkstyle.version>9.0.1</checkstyle.version>
+    <maven-install-plugin.version>3.1.1</maven-install-plugin.version>
+    <maven-deploy-plugin.version>3.1.1</maven-deploy-plugin.version>
+    <maven-site-plugin.version>3.12.1</maven-site-plugin.version>
+    <maven-project-info-reports-plugin.version>3.4.3</maven-project-info-reports-plugin.version>
+    <maven-checkstyle-plugin.version>3.2.2</maven-checkstyle-plugin.version>
+    <checkstyle.version>10.10.0</checkstyle.version>
 
     <!-- plugins -->
     <maven-eclipse-plugin.version>2.10</maven-eclipse-plugin.version>
     <jetty-runner.version>${jetty.version}</jetty-runner.version>
     <jetty-maven-plugin.version>${jetty.version}</jetty-maven-plugin.version>
-    <duplicate-finder-maven-plugin.version>1.5.0</duplicate-finder-maven-plugin.version>
-    <maven-javadoc-plugin.version>3.3.1</maven-javadoc-plugin.version>
+    <duplicate-finder-maven-plugin.version>1.5.1</duplicate-finder-maven-plugin.version>
+    <maven-javadoc-plugin.version>3.5.0</maven-javadoc-plugin.version>
   </properties>
 
   <dependencies>
@@ -145,13 +148,6 @@
         </exclusion>
       </exclusions>
     </dependency>
-    <dependency>
-      <!-- batik-all generally tends to provide duplicate resources on the classpath -->
-      <groupId>org.apache.xmlgraphics</groupId>
-      <artifactId>batik-all</artifactId>
-      <version>${batik-all.version}</version>
-      <type>pom</type>
-    </dependency>  
     <!-- jlatexmath -->
     <dependency>
       <groupId>org.scilab.forge</groupId>
@@ -168,12 +164,33 @@
       <artifactId>jlatexmath-font-cyrillic</artifactId>
       <version>${jlatexmath-font-cyrillic.version}</version>
     </dependency>
+    <!-- PDF -->
+    <dependency>
+      <!-- batik-all generally tends to provide duplicate resources on the classpath -->
+      <groupId>org.apache.xmlgraphics</groupId>
+      <artifactId>batik-all</artifactId>
+      <version>${batik-all.version}</version>
+      <type>pom</type>
+    </dependency>
+    <dependency>
+      <!-- fop generally tends to provide duplicate resources on the classpath -->
+      <groupId>org.apache.xmlgraphics</groupId>
+      <artifactId>fop</artifactId>
+      <version>${fop.version}</version>
+      <type>pom</type>
+    </dependency>
 
     <!-- Testing -->
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
       <version>${junit.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.platform</groupId>
+      <artifactId>junit-platform-suite-api</artifactId>
+      <version>${junit-suite.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -220,7 +237,7 @@
         <plugin>
           <artifactId>maven-dependency-plugin</artifactId>
           <version>${maven-dependency-plugin.version}</version>
-        </plugin>      
+        </plugin>
         <plugin>
           <artifactId>maven-resources-plugin</artifactId>
           <version>${maven-resources-plugin.version}</version>

--- a/pom.xml
+++ b/pom.xml
@@ -55,7 +55,7 @@
     <!-- main versions -->
     <plantuml.version>1.2023.6</plantuml.version>
     <!-- Please keep the jetty version identical with the docker image -->
-    <jetty.version>11.0.7</jetty.version>
+    <jetty.version>11.0.15</jetty.version>
     <monaco-editor.version>0.36.1</monaco-editor.version>
 
     <!-- dependencies -->
@@ -63,41 +63,44 @@
     <apache-jsp.version>${jetty.version}</apache-jsp.version>
     <jetty-annotations.version>${jetty.version}</jetty-annotations.version>
     <glassfish-jstl.version>${jetty.version}</glassfish-jstl.version>
-    <batik-all.version>1.14</batik-all.version>
     <!-- jlatexmath -->
     <jlatexmath.version>1.0.7</jlatexmath.version>
     <jlatexmath-font-greek.version>${jlatexmath.version}</jlatexmath-font-greek.version>
     <jlatexmath-font-cyrillic.version>${jlatexmath.version}</jlatexmath-font-cyrillic.version>
+    <!-- PDF -->
+    <batik-all.version>1.16</batik-all.version>
+    <fop.version>2.8</fop.version>
 
     <!-- Testing -->
-    <junit.version>4.13.2</junit.version>
-    <selenium.version>4.8.3</selenium.version>
+    <junit.version>5.9.3</junit.version>
+    <junit-suite.version>1.9.3</junit-suite.version>
+    <selenium.version>4.9.0</selenium.version>
     <selenium-webdrivermanager.version>5.3.2</selenium-webdrivermanager.version>
     <commons-io.version>2.11.0</commons-io.version>
     <jetty-server.version>${jetty.version}</jetty-server.version>
 
     <!-- build plugin management -->
     <!-- lock down plugins versions to avoid using Maven defaults -->
-    <maven-clean-plugin.version>3.1.0</maven-clean-plugin.version>
-    <maven-dependency-plugin.version>3.2.0</maven-dependency-plugin.version>
-    <maven-resources-plugin.version>3.2.0</maven-resources-plugin.version>
-    <maven-compiler-plugin.version>3.8.1</maven-compiler-plugin.version>
-    <versions-maven-plugin.version>2.8.1</versions-maven-plugin.version>
-    <maven-surefire-plugin.version>2.22.2</maven-surefire-plugin.version>
+    <maven-clean-plugin.version>3.2.0</maven-clean-plugin.version>
+    <maven-dependency-plugin.version>3.5.0</maven-dependency-plugin.version>
+    <maven-resources-plugin.version>3.3.1</maven-resources-plugin.version>
+    <maven-compiler-plugin.version>3.11.0</maven-compiler-plugin.version>
+    <versions-maven-plugin.version>2.15.0</versions-maven-plugin.version>
+    <maven-surefire-plugin.version>3.0.0</maven-surefire-plugin.version>
     <maven-war-plugin.version>3.3.2</maven-war-plugin.version>
-    <maven-install-plugin.version>2.5.2</maven-install-plugin.version>
-    <maven-deploy-plugin.version>2.8.2</maven-deploy-plugin.version>
-    <maven-site-plugin.version>3.9.1</maven-site-plugin.version>
-    <maven-project-info-reports-plugin.version>3.1.2</maven-project-info-reports-plugin.version>
-    <maven-checkstyle-plugin.version>3.1.2</maven-checkstyle-plugin.version>
-    <checkstyle.version>9.0.1</checkstyle.version>
+    <maven-install-plugin.version>3.1.1</maven-install-plugin.version>
+    <maven-deploy-plugin.version>3.1.1</maven-deploy-plugin.version>
+    <maven-site-plugin.version>3.12.1</maven-site-plugin.version>
+    <maven-project-info-reports-plugin.version>3.4.3</maven-project-info-reports-plugin.version>
+    <maven-checkstyle-plugin.version>3.2.2</maven-checkstyle-plugin.version>
+    <checkstyle.version>10.10.0</checkstyle.version>
 
     <!-- plugins -->
     <maven-eclipse-plugin.version>2.10</maven-eclipse-plugin.version>
     <jetty-runner.version>${jetty.version}</jetty-runner.version>
     <jetty-maven-plugin.version>${jetty.version}</jetty-maven-plugin.version>
-    <duplicate-finder-maven-plugin.version>1.5.0</duplicate-finder-maven-plugin.version>
-    <maven-javadoc-plugin.version>3.3.1</maven-javadoc-plugin.version>
+    <duplicate-finder-maven-plugin.version>1.5.1</duplicate-finder-maven-plugin.version>
+    <maven-javadoc-plugin.version>3.5.0</maven-javadoc-plugin.version>
   </properties>
 
   <dependencies>
@@ -123,13 +126,6 @@
       <version>${jetty-annotations.version}</version>
       <scope>provided</scope>
     </dependency>
-    <dependency>
-      <!-- batik-all generally tends to provide duplicate resources on the classpath -->
-      <groupId>org.apache.xmlgraphics</groupId>
-      <artifactId>batik-all</artifactId>
-      <version>${batik-all.version}</version>
-      <type>pom</type>
-    </dependency>  
     <!-- jlatexmath -->
     <dependency>
       <groupId>org.scilab.forge</groupId>
@@ -146,12 +142,33 @@
       <artifactId>jlatexmath-font-cyrillic</artifactId>
       <version>${jlatexmath-font-cyrillic.version}</version>
     </dependency>
- 
+    <!-- PDF -->
+    <dependency>
+      <!-- batik-all generally tends to provide duplicate resources on the classpath -->
+      <groupId>org.apache.xmlgraphics</groupId>
+      <artifactId>batik-all</artifactId>
+      <version>${batik-all.version}</version>
+      <type>pom</type>
+    </dependency>
+    <dependency>
+      <!-- fop generally tends to provide duplicate resources on the classpath -->
+      <groupId>org.apache.xmlgraphics</groupId>
+      <artifactId>fop</artifactId>
+      <version>${fop.version}</version>
+      <type>pom</type>
+    </dependency>
+
    <!-- Testing -->
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
       <version>${junit.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.platform</groupId>
+      <artifactId>junit-platform-suite-api</artifactId>
+      <version>${junit-suite.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -178,15 +195,6 @@
       <version>${jetty-server.version}</version>
       <scope>test</scope>
     </dependency>
-	
-    <!-- PDF Dependencies -->
-    <dependency>
-      <!-- fop generally tends to provide duplicate resources on the classpath -->
-      <groupId>org.apache.xmlgraphics</groupId>
-      <artifactId>fop</artifactId>
-      <version>2.7</version>
-      <type>pom</type>
-    </dependency>
   </dependencies>
 
   <build>
@@ -201,7 +209,7 @@
         <plugin>
           <artifactId>maven-dependency-plugin</artifactId>
           <version>${maven-dependency-plugin.version}</version>
-        </plugin>      
+        </plugin>
         <plugin>
           <artifactId>maven-resources-plugin</artifactId>
           <version>${maven-resources-plugin.version}</version>

--- a/src/main/config/rules.xml
+++ b/src/main/config/rules.xml
@@ -14,6 +14,7 @@
     <ignoreVersion type="regex">(?i).*RC(?:-?\d+)?</ignoreVersion>
     <ignoreVersion type="regex">(?i).*CR(?:-?\d+)?</ignoreVersion>
     <ignoreVersion type="regex">(?i).*M(?:-?\d+)?</ignoreVersion>
+    <ignoreVersion type="regex">(?i).*-dev((?:-?\d+)|(?:\.20\d{6}))?</ignoreVersion>
   </ignoreVersions>
   <rules>
     <rule groupId="net.sourceforge.plantuml" artifactId="plantuml" comparisonMethod="maven">

--- a/src/test/java/net/sourceforge/plantuml/servlet/AllTests.java
+++ b/src/test/java/net/sourceforge/plantuml/servlet/AllTests.java
@@ -1,28 +1,22 @@
 package net.sourceforge.plantuml.servlet;
 
-import junit.framework.Test;
-import junit.framework.TestSuite;
+import org.junit.platform.suite.api.SelectClasses;
+import org.junit.platform.suite.api.Suite;
 
-public class AllTests extends TestSuite {
-
-    public static Test suite() {
-        TestSuite suite = new TestSuite(AllTests.class.getName());
-        // $JUnit-BEGIN$
-        suite.addTestSuite(TestAsciiArt.class);
-        suite.addTestSuite(TestAsciiCoder.class);
-        suite.addTestSuite(TestCharset.class);
-        suite.addTestSuite(TestCheck.class);
-        suite.addTestSuite(TestEPS.class);
-        suite.addTestSuite(TestImage.class);
-        suite.addTestSuite(TestLanguage.class);
-        suite.addTestSuite(TestMap.class);
-        suite.addTestSuite(TestMultipageUml.class);
-        suite.addTestSuite(TestOldProxy.class);
-        suite.addTestSuite(TestProxy.class);
-        suite.addTestSuite(TestSVG.class);
-        suite.addTestSuite(TestWebUI.class);
-        // $JUnit-END$
-        return suite;
-    }
-
-}
+@Suite
+@SelectClasses({
+    TestAsciiArt.class,
+    TestAsciiCoder.class,
+    TestCharset.class,
+    TestCheck.class,
+    TestEPS.class,
+    TestImage.class,
+    TestLanguage.class,
+    TestMap.class,
+    TestMultipageUml.class,
+    TestOldProxy.class,
+    TestProxy.class,
+    TestSVG.class,
+    TestWebUI.class
+})
+public class AllTests {}

--- a/src/test/java/net/sourceforge/plantuml/servlet/TestAsciiArt.java
+++ b/src/test/java/net/sourceforge/plantuml/servlet/TestAsciiArt.java
@@ -4,6 +4,9 @@ import java.io.IOException;
 import java.net.URL;
 import java.net.URLConnection;
 
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
 import net.sourceforge.plantuml.servlet.utils.TestUtils;
 import net.sourceforge.plantuml.servlet.utils.WebappTestCase;
 
@@ -13,21 +16,22 @@ public class TestAsciiArt extends WebappTestCase {
     /**
      * Verifies the generation of the ascii art for the Bob -> Alice sample
      */
+    @Test
     public void testSimpleSequenceDiagram() throws IOException {
         final URL url = new URL(getServerUrl() + "/txt/" + TestUtils.SEQBOB);
         final URLConnection conn = url.openConnection();
         // Analyze response
         // Verifies the Content-Type header
-        assertEquals(
-            "Response content type is not TEXT PLAIN or UTF-8",
+        Assertions.assertEquals(
             "text/plain;charset=utf-8",
-            conn.getContentType().toLowerCase()
+            conn.getContentType().toLowerCase(),
+            "Response content type is not TEXT PLAIN or UTF-8"
         );
         // Get the content and verify its size
         String diagram = getContentText(conn);
         int diagramLen = diagram.length();
-        assertTrue(diagramLen > 200);
-        assertTrue(diagramLen < 250);
+        Assertions.assertTrue(diagramLen > 200);
+        Assertions.assertTrue(diagramLen < 250);
     }
 
 }

--- a/src/test/java/net/sourceforge/plantuml/servlet/TestAsciiCoder.java
+++ b/src/test/java/net/sourceforge/plantuml/servlet/TestAsciiCoder.java
@@ -6,6 +6,9 @@ import java.net.HttpURLConnection;
 import java.net.URL;
 import java.net.URLConnection;
 
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
 import net.sourceforge.plantuml.servlet.utils.TestUtils;
 import net.sourceforge.plantuml.servlet.utils.WebappTestCase;
 
@@ -15,24 +18,26 @@ public class TestAsciiCoder extends WebappTestCase {
     /**
      * Verifies the decoding for the Bob -> Alice sample
      */
+    @Test
     public void testBobAliceSampleDiagramDecoding() throws IOException {
         final URL url = new URL(getServerUrl() + "/coder/" + TestUtils.SEQBOB);
         final URLConnection conn = url.openConnection();
         // Analyze response
         // Verifies the Content-Type header
-        assertEquals(
-            "Response content type is not TEXT PLAIN or UTF-8",
+        Assertions.assertEquals(
             "text/plain;charset=utf-8",
-            conn.getContentType().toLowerCase()
+            conn.getContentType().toLowerCase(),
+            "Response content type is not TEXT PLAIN or UTF-8"
         );
         // Get and verify the content
         final String diagram = getContentText(conn);
-        assertEquals(TestUtils.SEQBOBCODE, diagram);
+        Assertions.assertEquals(TestUtils.SEQBOBCODE, diagram);
     }
 
     /**
      * Verifies the encoding for the Bob -> Alice sample
      */
+    @Test
     public void testBobAliceSampleDiagramEncoding() throws IOException {
         final URL url = new URL(getServerUrl() + "/coder");
         final HttpURLConnection conn = (HttpURLConnection)url.openConnection();
@@ -45,20 +50,16 @@ public class TestAsciiCoder extends WebappTestCase {
         }
         // Analyze response
         // HTTP response 200
-        assertEquals(
-            "Bad HTTP status received",
-            200,
-            conn.getResponseCode()
-        );
+        Assertions.assertEquals(200, conn.getResponseCode(), "Bad HTTP status received");
         // Verifies the Content-Type header
-        assertEquals(
-            "Response content type is not TEXT PLAIN or UTF-8",
+        Assertions.assertEquals(
             "text/plain;charset=utf-8",
-            conn.getContentType().toLowerCase()
+            conn.getContentType().toLowerCase(),
+            "Response content type is not TEXT PLAIN or UTF-8"
         );
         // Get the content and verify its size
         final String diagram = getContentText(conn.getInputStream());
-        assertEquals(TestUtils.SEQBOB, diagram);
+        Assertions.assertEquals(TestUtils.SEQBOB, diagram);
     }
 
 }

--- a/src/test/java/net/sourceforge/plantuml/servlet/TestCharset.java
+++ b/src/test/java/net/sourceforge/plantuml/servlet/TestCharset.java
@@ -4,6 +4,9 @@ import java.io.IOException;
 import java.net.URL;
 import java.net.URLConnection;
 
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
 import net.sourceforge.plantuml.servlet.utils.WebappTestCase;
 
 
@@ -12,25 +15,27 @@ public class TestCharset extends WebappTestCase {
     /**
      * Verifies the preservation of unicode characters for the "Bob -> Alice : hell‽" sample
      */
+    @Test
     public void testUnicodeSupport() throws IOException {
         final URL url = new URL(getServerUrl() + "/txt/SyfFKj2rKt3CoKnELR1Io4ZDoNdKi1S0");
         final URLConnection conn = url.openConnection();
         // Analyze response
         // Verifies the Content-Type header
-        assertEquals(
-            "Response content type is not TEXT PLAIN or UTF-8",
+        Assertions.assertEquals(
             "text/plain;charset=utf-8",
-            conn.getContentType().toLowerCase()
+            conn.getContentType().toLowerCase(),
+            "Response content type is not TEXT PLAIN or UTF-8"
         );
         // Get the content and verify that the interrobang unicode character is present
         String diagram = getContentText(conn);
-        assertTrue("Interrobang unicode character is not preserved", diagram.contains("‽"));
+        Assertions.assertTrue(diagram.contains("‽"), "Interrobang unicode character is not preserved");
     }
 
     /**
      * Verifies the preservation of unicode characters for the
      * "participant Bob [[http://www.snow.com/❄]]\nBob -> Alice" sample
      */
+    @Test
     public void testUnicodeInCMap() throws IOException {
         final URL url = new URL(
             getServerUrl() +
@@ -39,14 +44,14 @@ public class TestCharset extends WebappTestCase {
         final URLConnection conn = url.openConnection();
         // Analyze response
         // Verifies the Content-Type header
-        assertEquals(
-            "Response content type is not TEXT PLAIN or UTF-8",
+        Assertions.assertEquals(
             "text/plain;charset=utf-8",
-            conn.getContentType().toLowerCase()
+            conn.getContentType().toLowerCase(),
+            "Response content type is not TEXT PLAIN or UTF-8"
         );
         // Get the content and verify that the snow unicode character is present
         String map = getContentText(conn);
-        assertTrue("Snow unicode character is not preserved", map.contains("❄"));
+        Assertions.assertTrue(map.contains("❄"), "Snow unicode character is not preserved");
     }
 
 }

--- a/src/test/java/net/sourceforge/plantuml/servlet/TestCheck.java
+++ b/src/test/java/net/sourceforge/plantuml/servlet/TestCheck.java
@@ -4,6 +4,9 @@ import java.io.IOException;
 import java.net.URL;
 import java.net.URLConnection;
 
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
 import net.sourceforge.plantuml.servlet.utils.TestUtils;
 import net.sourceforge.plantuml.servlet.utils.WebappTestCase;
 
@@ -14,36 +17,38 @@ public class TestCheck extends WebappTestCase {
      * Verifies the generation of a syntax check for the following sample:
      * Bob -> Alice : hello
      */
+    @Test
     public void testCorrectSequenceDiagram() throws IOException {
         final URL url = new URL(getServerUrl() + "/check/" + TestUtils.SEQBOB);
         final URLConnection conn = url.openConnection();
         // Analyze response
         // Verifies the Content-Type header
-        assertEquals(
-            "Response content type is not TEXT PLAIN or UTF-8",
+        Assertions.assertEquals(
             "text/plain;charset=utf-8",
-            conn.getContentType().toLowerCase()
+            conn.getContentType().toLowerCase(),
+            "Response content type is not TEXT PLAIN or UTF-8"
         );
         // Get the content, check its first characters and verify its size
         String checkResult = getContentText(conn);
-        assertTrue(
-            "Response content is not starting with (2 participants)",
-            checkResult.startsWith("(2 participants)")
+        Assertions.assertTrue(
+            checkResult.startsWith("(2 participants)"),
+            "Response content is not starting with (2 participants)"
         );
         int checkLen = checkResult.length();
-        assertTrue(checkLen > 1);
-        assertTrue(checkLen < 100);
+        Assertions.assertTrue(checkLen > 1);
+        Assertions.assertTrue(checkLen < 100);
     }
 
     /**
      * Check the syntax of an invalid sequence diagram :
      * Bob -
      */
+    @Test
     public void testWrongDiagramSyntax() throws IOException {
         final URL url = new URL(getServerUrl() + "/check/SyfFKj050000");
         // Analyze response
         String checkResult = getContentText(url);
-        assertTrue("Response is not an error", checkResult.startsWith("(Error)"));
+        Assertions.assertTrue(checkResult.startsWith("(Error)"), "Response is not an error");
     }
 
 }

--- a/src/test/java/net/sourceforge/plantuml/servlet/TestEPS.java
+++ b/src/test/java/net/sourceforge/plantuml/servlet/TestEPS.java
@@ -4,6 +4,9 @@ import java.io.IOException;
 import java.net.URL;
 import java.net.URLConnection;
 
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
 import net.sourceforge.plantuml.servlet.utils.TestUtils;
 import net.sourceforge.plantuml.servlet.utils.WebappTestCase;
 
@@ -13,21 +16,22 @@ public class TestEPS extends WebappTestCase {
     /**
      * Verifies the generation of the EPS for the Bob -> Alice sample
      */
+    @Test
     public void testSimpleSequenceDiagram() throws IOException {
         final URL url = new URL(getServerUrl() + "/eps/" + TestUtils.SEQBOB);
         final URLConnection conn = url.openConnection();
         // Analyze response
         // Verifies the Content-Type header
-        assertEquals(
-            "Response content type is not EPS",
+        Assertions.assertEquals(
             "application/postscript",
-            conn.getContentType().toLowerCase()
+            conn.getContentType().toLowerCase(),
+            "Response content type is not EPS"
         );
         // Get the content and verify its size
         String diagram = getContentText(conn);
         int diagramLen = diagram.length();
-        assertTrue(diagramLen > 7000);
-        assertTrue(diagramLen < 10000);
+        Assertions.assertTrue(diagramLen > 7000);
+        Assertions.assertTrue(diagramLen < 10000);
     }
 
 }

--- a/src/test/java/net/sourceforge/plantuml/servlet/TestImage.java
+++ b/src/test/java/net/sourceforge/plantuml/servlet/TestImage.java
@@ -8,6 +8,9 @@ import java.text.SimpleDateFormat;
 import java.util.Date;
 import java.util.Locale;
 
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
 import net.sourceforge.plantuml.servlet.utils.TestUtils;
 import net.sourceforge.plantuml.servlet.utils.WebappTestCase;
 
@@ -17,44 +20,46 @@ public class TestImage extends WebappTestCase {
     /**
      * Verifies the generation of the version image from an encoded URL
      */
+    @Test
     public void testVersionImage() throws IOException {
         final URL url = new URL(getServerUrl() + "/png/" + TestUtils.VERSION);
         final URLConnection conn = url.openConnection();
         // Analyze response
         // Verifies the Content-Type header
-        assertEquals(
-            "Response content type is not PNG",
+        Assertions.assertEquals(
             "image/png",
-            conn.getContentType().toLowerCase()
+            conn.getContentType().toLowerCase(),
+            "Response content type is not PNG"
         );
         // Get the image and verify its size
         byte[] inMemoryImage = getContentAsBytes(conn);
         int diagramLen = inMemoryImage.length;
-        assertTrue(diagramLen > 10000);
-        assertTrue(diagramLen < 20000);
+        Assertions.assertTrue(diagramLen > 10000);
+        Assertions.assertTrue(diagramLen < 20000);
     }
 
     /**
      * Verifies that the HTTP header of a diagram incites the browser to cache it.
      */
+    @Test
     public void testDiagramHttpHeader() throws IOException, ParseException {
         final URL url = new URL(getServerUrl() + "/png/" + TestUtils.SEQBOB);
         final URLConnection conn = url.openConnection();
         // Analyze response
         // Verifies the Content-Type header
-        assertEquals(
-            "Response content type is not PNG",
+        Assertions.assertEquals(
             "image/png",
-            conn.getContentType().toLowerCase()
+            conn.getContentType().toLowerCase(),
+            "Response content type is not PNG"
         );
         // Verifies the availability of the Expires entry in the response header
-        assertNotNull(conn.getHeaderField("Expires"));
+        Assertions.assertNotNull(conn.getHeaderField("Expires"));
         // Verifies the availability of the Last-Modified entry in the response header
-        assertNotNull(conn.getHeaderField("Last-Modified"));
+        Assertions.assertNotNull(conn.getHeaderField("Last-Modified"));
         // Verifies the Last-Modified value is in the past
         SimpleDateFormat format = new SimpleDateFormat("EEE, dd MMM yyyy HH:mm:ss ZZZ", Locale.ENGLISH);
         Date lastModified = format.parse(conn.getHeaderField("Last-Modified"));
-        assertTrue("Last-Modified is not in the past", lastModified.before(new Date()));
+        Assertions.assertTrue(lastModified.before(new Date()), "Last-Modified is not in the past");
         // Consume the response but do nothing with it
         getContentAsBytes(conn);
     }
@@ -62,15 +67,16 @@ public class TestImage extends WebappTestCase {
     /**
      * Verifies that the HTTP header of a diagram incites the browser to cache it.
      */
+    @Test
     public void testOldImgURL() throws IOException {
         final URL url = new URL(getServerUrl() + "/img/" + TestUtils.SEQBOB);
         final URLConnection conn = url.openConnection();
         // Analyze response
         // Verifies the Content-Type header
-        assertEquals(
-            "Response content type is not PNG",
+        Assertions.assertEquals(
             "image/png",
-            conn.getContentType().toLowerCase()
+            conn.getContentType().toLowerCase(),
+            "Response content type is not PNG"
         );
         // Consume the response but do nothing with it
         getContentAsBytes(conn);

--- a/src/test/java/net/sourceforge/plantuml/servlet/TestLanguage.java
+++ b/src/test/java/net/sourceforge/plantuml/servlet/TestLanguage.java
@@ -3,6 +3,9 @@ package net.sourceforge.plantuml.servlet;
 import java.io.IOException;
 import java.net.URL;
 
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
 import net.sourceforge.plantuml.servlet.utils.WebappTestCase;
 
 
@@ -11,10 +14,11 @@ public class TestLanguage extends WebappTestCase {
     /**
      * Tests that the language for the current PlantUML server can be obtained through HTTP
      */
+    @Test
     public void testRetrieveLanguage() throws IOException {
         final URL url = new URL(getServerUrl() + "/language");
         String languageText = getContentText(url);
-        assertTrue("Language contains @startuml", languageText.indexOf("@startuml") > 0);
+        Assertions.assertTrue(languageText.indexOf("@startuml") > 0, "Language contains @startuml");
     }
 
 }

--- a/src/test/java/net/sourceforge/plantuml/servlet/TestMap.java
+++ b/src/test/java/net/sourceforge/plantuml/servlet/TestMap.java
@@ -4,6 +4,9 @@ import java.io.IOException;
 import java.net.URL;
 import java.net.URLConnection;
 
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
 import net.sourceforge.plantuml.servlet.utils.TestUtils;
 import net.sourceforge.plantuml.servlet.utils.WebappTestCase;
 
@@ -16,6 +19,7 @@ public class TestMap extends WebappTestCase {
      * participant Bob [[http://www.yahoo.com]]
      * Bob -> Alice : [[http://www.google.com]] hello
      */
+    @Test
     public void testSimpleSequenceDiagram() throws IOException {
         final URL url = new URL(
             getServerUrl() +
@@ -24,30 +28,31 @@ public class TestMap extends WebappTestCase {
         final URLConnection conn = url.openConnection();
         // Analyze response
         // Verifies the Content-Type header
-        assertEquals(
-            "Response content type is not TEXT PLAIN or UTF-8",
+        Assertions.assertEquals(
             "text/plain;charset=utf-8",
-            conn.getContentType().toLowerCase()
+            conn.getContentType().toLowerCase(),
+            "Response content type is not TEXT PLAIN or UTF-8"
         );
         // Get the content, check its first characters and verify its size
         String diagram = getContentText(conn);
-        assertTrue(
-            "Response content is not starting with <map",
-            diagram.startsWith("<map")
+        Assertions.assertTrue(
+            diagram.startsWith("<map"),
+            "Response content is not starting with <map"
         );
-        assertTrue(
-            "Response content (2. line) is not starting with <area",
-            diagram.split("\\n", 2)[1].startsWith("<area")
+        Assertions.assertTrue(
+            diagram.split("\\n", 2)[1].startsWith("<area"),
+            "Response content (2. line) is not starting with <area"
         );
         int diagramLen = diagram.length();
-        assertTrue(diagramLen > 200);
-        assertTrue(diagramLen < 300);
+        Assertions.assertTrue(diagramLen > 200);
+        Assertions.assertTrue(diagramLen < 300);
     }
 
     /**
      * Check the content of the MAP for the sequence diagram sample
      * Verify structure of the area tags
      */
+    @Test
     public void testSequenceDiagramContent() throws IOException {
         final URL url = new URL(
             getServerUrl() +
@@ -61,9 +66,9 @@ public class TestMap extends WebappTestCase {
         // <area shape="..." id="..." href="..." ... />
         // <area shape="..." id="..." href="..." ... />
         // </map>
-        assertTrue(
-            "Response doesn't match shape",
-            map.matches("^<map id=\".+\" name=\".+\">\n(<area shape=\".+\" id=\".+\" href=\".+\".*/>\n){2}</map>\n*$")
+        Assertions.assertTrue(
+            map.matches("^<map id=\".+\" name=\".+\">\n(<area shape=\".+\" id=\".+\" href=\".+\".*/>\n){2}</map>\n*$"),
+            "Response doesn't match shape"
         );
     }
 
@@ -71,20 +76,21 @@ public class TestMap extends WebappTestCase {
      * Check the empty MAP of a sequence diagram without link
      * This test uses the simple Bob -> Alice
      */
+    @Test
     public void testSequenceDiagramWithoutLink() throws IOException {
         final URL url = new URL(getServerUrl() + "/map/" + TestUtils.SEQBOB);
         final URLConnection conn = url.openConnection();
         // Analyze response
         // Verifies the Content-Type header
-        assertEquals(
-            "Response content type is not TEXT PLAIN or UTF-8",
+        Assertions.assertEquals(
             "text/plain;charset=utf-8",
-            conn.getContentType().toLowerCase()
+            conn.getContentType().toLowerCase(),
+            "Response content type is not TEXT PLAIN or UTF-8"
         );
         // Get the data contained in the XML
         String diagram = getContentText(conn);
         int diagramLen = diagram.length();
-        assertEquals(0, diagramLen);
+        Assertions.assertEquals(0, diagramLen);
     }
 
 }

--- a/src/test/java/net/sourceforge/plantuml/servlet/TestMultipageUml.java
+++ b/src/test/java/net/sourceforge/plantuml/servlet/TestMultipageUml.java
@@ -1,10 +1,11 @@
 package net.sourceforge.plantuml.servlet;
 
-import static org.junit.Assert.assertNotEquals;
-
 import java.io.IOException;
 import java.net.HttpURLConnection;
 import java.net.URL;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import net.sourceforge.plantuml.servlet.utils.TestUtils;
 import net.sourceforge.plantuml.servlet.utils.WebappTestCase;
@@ -15,182 +16,190 @@ public class TestMultipageUml extends WebappTestCase {
     /**
      * Verifies that an multipage diagram renders correct given index (PNG).
      */
+    @Test
     public void testPngIndexPage() throws IOException {
         final URL url = new URL(getServerUrl() + "/png/1/" + TestUtils.SEQMULTIPAGE);
         final HttpURLConnection conn = (HttpURLConnection)url.openConnection();
         // Analyze response
         // Verifies HTTP status code and the Content-Type
-        assertEquals("Bad HTTP status received", 200, conn.getResponseCode());
-        assertEquals(
-            "Response content type is not PNG",
+        Assertions.assertEquals(200, conn.getResponseCode(), "Bad HTTP status received");
+        Assertions.assertEquals(
             "image/png",
-            conn.getContentType().toLowerCase()
+            conn.getContentType().toLowerCase(),
+            "Response content type is not PNG"
         );
         // Get the image and verify its size
         byte[] inMemoryImage = getContentAsBytes(conn);
         int diagramLen = inMemoryImage.length;  // 7525
-        assertTrue(diagramLen > 6000);
-        assertTrue(diagramLen < 9000);
+        Assertions.assertTrue(diagramLen > 6000);
+        Assertions.assertTrue(diagramLen < 9000);
     }
 
     /**
      * Verifies that an multipage diagram renders correct even if no index is specified (PNG).
      */
+    @Test
     public void testPngIndexPageNoIndex() throws IOException {
         final URL url = new URL(getServerUrl() + "/png/" + TestUtils.SEQMULTIPAGE);
         final HttpURLConnection conn = (HttpURLConnection)url.openConnection();
         // Analyze response
         // Verifies HTTP status code and the Content-Type
-        assertEquals("Bad HTTP status received", 200, conn.getResponseCode());
-        assertEquals(
-            "Response content type is not PNG",
+        Assertions.assertEquals(200, conn.getResponseCode(), "Bad HTTP status received");
+        Assertions.assertEquals(
             "image/png",
-            conn.getContentType().toLowerCase()
+            conn.getContentType().toLowerCase(),
+            "Response content type is not PNG"
         );
         // Get the image and verify its size
         byte[] inMemoryImage = getContentAsBytes(conn);
         int diagramLen = inMemoryImage.length;  // 4196
-        assertTrue(diagramLen > 3000);
-        assertTrue(diagramLen < 5000);
+        Assertions.assertTrue(diagramLen > 3000);
+        Assertions.assertTrue(diagramLen < 5000);
     }
 
     /**
      * Verifies that an multipage diagram renders correct given index (SVG).
      */
+    @Test
     public void testSvgIndexPage() throws IOException {
         final URL url = new URL(getServerUrl() + "/svg/1/" + TestUtils.SEQMULTIPAGE);
         final HttpURLConnection conn = (HttpURLConnection)url.openConnection();
         // Analyze response
         // Verifies HTTP status code and the Content-Type
-        assertEquals("Bad HTTP status received", 200, conn.getResponseCode());
-        assertEquals(
-            "Response content type is not SVG",
+        Assertions.assertEquals(200, conn.getResponseCode(), "Bad HTTP status received");
+        Assertions.assertEquals(
             "image/svg+xml",
-            conn.getContentType().toLowerCase()
+            conn.getContentType().toLowerCase(),
+            "Response content type is not SVG"
         );
         // Get the content and verify its size
         String diagram = getContentText(conn);
         int diagramLen = diagram.length();
-        assertTrue(diagramLen > 4500);
-        assertTrue(diagramLen < 6000);
+        Assertions.assertTrue(diagramLen > 4500);
+        Assertions.assertTrue(diagramLen < 6000);
     }
 
     /**
      * Verifies that an multipage diagram renders correct even if no index is specified (SVG).
      */
+    @Test
     public void testSvgIndexPageNoIndex() throws IOException {
         final URL url = new URL(getServerUrl() + "/svg/" + TestUtils.SEQMULTIPAGE);
         final HttpURLConnection conn = (HttpURLConnection)url.openConnection();
         // Analyze response
         // Verifies HTTP status code and the Content-Type
-        assertEquals("Bad HTTP status received", 200, conn.getResponseCode());
-        assertEquals(
-            "Response content type is not SVG",
+        Assertions.assertEquals(200, conn.getResponseCode(), "Bad HTTP status received");
+        Assertions.assertEquals(
             "image/svg+xml",
-            conn.getContentType().toLowerCase()
+            conn.getContentType().toLowerCase(),
+            "Response content type is not SVG"
         );
         // Get the content and verify its size
         String diagram = getContentText(conn);
         int diagramLen = diagram.length();
-        assertTrue(diagramLen > 1500);
-        assertTrue(diagramLen < 4000);
+        Assertions.assertTrue(diagramLen > 1500);
+        Assertions.assertTrue(diagramLen < 4000);
     }
 
     /**
      * Verifies that an multipage diagram renders correct given index (AsciiArt).
      */
+    @Test
     public void testAsciiArtIndexPage() throws IOException {
         final URL url = new URL(getServerUrl() + "/txt/1/" + TestUtils.SEQMULTIPAGE);
         final HttpURLConnection conn = (HttpURLConnection)url.openConnection();
         // Analyze response
         // Verifies HTTP status code and the Content-Type
-        assertEquals("Bad HTTP status received", 200, conn.getResponseCode());
-        assertEquals(
-            "Response content type is not TEXT PLAIN or UTF-8",
+        Assertions.assertEquals(200, conn.getResponseCode(), "Bad HTTP status received");
+        Assertions.assertEquals(
             "text/plain;charset=utf-8",
-            conn.getContentType().toLowerCase()
+            conn.getContentType().toLowerCase(),
+            "Response content type is not TEXT PLAIN or UTF-8"
         );
         // Get the content and verify its size
         String diagram = getContentText(conn);
         int diagramLen = diagram.length();
-        assertNotEquals(0, diagramLen);
+        Assertions.assertNotEquals(0, diagramLen);
         // BUG/Missing Feature: plantuml renders always whole AsciiArt diagram
-        //assertTrue(diagramLen > ??);
-        //assertTrue(diagramLen < ??);
+        //Assertions.assertTrue(diagramLen > ??);
+        //Assertions.assertTrue(diagramLen < ??);
     }
 
     /**
      * Verifies that an multipage diagram renders correct even if no index is specified (AsciiArt).
      */
+    @Test
     public void testAsciiArtIndexPageNoIndex() throws IOException {
         final URL url = new URL(getServerUrl() + "/txt/" + TestUtils.SEQMULTIPAGE);
         final HttpURLConnection conn = (HttpURLConnection)url.openConnection();
         // Analyze response
         // Verifies HTTP status code and the Content-Type
-        assertEquals("Bad HTTP status received", 200, conn.getResponseCode());
-        assertEquals(
-            "Response content type is not TEXT PLAIN or UTF-8",
+        Assertions.assertEquals(200, conn.getResponseCode(), "Bad HTTP status received");
+        Assertions.assertEquals(
             "text/plain;charset=utf-8",
-            conn.getContentType().toLowerCase()
+            conn.getContentType().toLowerCase(),
+            "Response content type is not TEXT PLAIN or UTF-8"
         );
         // Get the content and verify its size
         String diagram = getContentText(conn);
         int diagramLen = diagram.length();
-        assertNotEquals(0, diagramLen);
+        Assertions.assertNotEquals(0, diagramLen);
         // BUG/Missing Feature: plantuml renders always whole AsciiArt diagram
-        //assertTrue(diagramLen > ??);
-        //assertTrue(diagramLen < ??);
+        //Assertions.assertTrue(diagramLen > ??);
+        //Assertions.assertTrue(diagramLen < ??);
     }
 
     /**
      * Verifies that an multipage diagram renders correct given index (Map).
      */
+    @Test
     public void testMapIndexPage() throws IOException {
         final URL url = new URL(getServerUrl() + "/map/1/" + TestUtils.SEQMULTIPAGE);
         final HttpURLConnection conn = (HttpURLConnection)url.openConnection();
         // Analyze response
         // Verifies HTTP status code and the Content-Type
-        assertEquals("Bad HTTP status received", 200, conn.getResponseCode());
-        assertEquals(
-            "Response content type is not TEXT PLAIN or UTF-8",
+        Assertions.assertEquals(200, conn.getResponseCode(), "Bad HTTP status received");
+        Assertions.assertEquals(
             "text/plain;charset=utf-8",
-            conn.getContentType().toLowerCase()
+            conn.getContentType().toLowerCase(),
+            "Response content type is not TEXT PLAIN or UTF-8"
         );
         // Get the data contained in the XML
         String map = getContentText(url);
         // map contains "tel:0123456789"
-        assertTrue(
-            "Response does not contain 'tel:0123456789'",
-            map.contains("tel:0123456789")
+        Assertions.assertTrue(
+            map.contains("tel:0123456789"),
+            "Response does not contain 'tel:0123456789'"
         );
         // Verify shape:
         // <map id="..." name="...">
         // <area shape="..." id="..." href="..." ... />
         // </map>
-        assertTrue(
-            "Response doesn't match shape",
-            map.matches("^<map id=\".+\" name=\".+\">\n(<area shape=\".+\" id=\".+\" href=\".+\".*/>\n)</map>\n*$")
+        Assertions.assertTrue(
+            map.matches("^<map id=\".+\" name=\".+\">\n(<area shape=\".+\" id=\".+\" href=\".+\".*/>\n)</map>\n*$"),
+            "Response doesn't match shape"
         );
     }
 
     /**
      * Verifies that an multipage diagram renders correct even if no index is specified (Map).
      */
+    @Test
     public void testMapIndexPageNoIndex() throws IOException {
         final URL url = new URL(getServerUrl() + "/map/" + TestUtils.SEQMULTIPAGE);
         final HttpURLConnection conn = (HttpURLConnection)url.openConnection();
         // Analyze response
         // Verifies HTTP status code and the Content-Type
-        assertEquals("Bad HTTP status received", 200, conn.getResponseCode());
-        assertEquals(
-            "Response content type is not TEXT PLAIN or UTF-8",
+        Assertions.assertEquals(200, conn.getResponseCode(), "Bad HTTP status received");
+        Assertions.assertEquals(
             "text/plain;charset=utf-8",
-            conn.getContentType().toLowerCase()
+            conn.getContentType().toLowerCase(),
+            "Response content type is not TEXT PLAIN or UTF-8"
         );
         // Get the data contained in the XML
         String diagram = getContentText(conn);
         int diagramLen = diagram.length();
-        assertEquals(0, diagramLen);
+        Assertions.assertEquals(0, diagramLen);
     }
 
 }

--- a/src/test/java/net/sourceforge/plantuml/servlet/TestOldProxy.java
+++ b/src/test/java/net/sourceforge/plantuml/servlet/TestOldProxy.java
@@ -4,6 +4,9 @@ import java.io.IOException;
 import java.net.HttpURLConnection;
 import java.net.URL;
 
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
 import net.sourceforge.plantuml.servlet.utils.WebappTestCase;
 
 
@@ -12,59 +15,61 @@ public class TestOldProxy extends WebappTestCase {
     /**
      * Verifies the proxified reception of the default Bob and Alice diagram
      */
+    @Test
     public void testDefaultProxy() throws IOException {
         final URL url = new URL(getServerUrl() + "/proxy/" + getTestDiagramUrl());
         final HttpURLConnection conn = (HttpURLConnection)url.openConnection();
         // Analyze response
         // Verifies HTTP status code and the Content-Type
-        assertEquals("Bad HTTP status received", 200, conn.getResponseCode());
-        assertEquals(
-            "Response content type is not PNG",
+        Assertions.assertEquals(200, conn.getResponseCode(), "Bad HTTP status received");
+        Assertions.assertEquals(
             "image/png",
-            conn.getContentType().toLowerCase()
+            conn.getContentType().toLowerCase(),
+            "Response content type is not PNG"
         );
         // Get the image and verify its size (~2000 bytes)
         byte[] inMemoryImage = getContentAsBytes(conn);
         int diagramLen = inMemoryImage.length;
-        assertTrue(diagramLen > 2000);
-        assertTrue(diagramLen < 3000);
+        Assertions.assertTrue(diagramLen > 2000);
+        Assertions.assertTrue(diagramLen < 3000);
     }
 
+    /**
+     * Verifies the proxified reception of the default Bob and Alice diagram in a specific format (SVG)
+     */
+    @Test
     public void testProxyWithFormat() throws IOException {
         final URL url = new URL(getServerUrl() + "/proxy/svg/" + getTestDiagramUrl());
         final HttpURLConnection conn = (HttpURLConnection)url.openConnection();
         // Analyze response
         // Verifies HTTP status code and the Content-Type
-        assertEquals("Bad HTTP status received", 200, conn.getResponseCode());
-        assertEquals(
-            "Response content type is not SVG",
+        Assertions.assertEquals(200, conn.getResponseCode(), "Bad HTTP status received");
+        Assertions.assertEquals(
             "image/svg+xml",
-            conn.getContentType().toLowerCase()
+            conn.getContentType().toLowerCase(),
+            "Response content type is not SVG"
         );
         // Get the content and verify its size
         String diagram = getContentText(conn);
         int diagramLen = diagram.length();
-        assertTrue(diagramLen > 1000);
-        assertTrue(diagramLen < 3000);
+        Assertions.assertTrue(diagramLen > 1000);
+        Assertions.assertTrue(diagramLen < 3000);
     }
 
     /**
      * Verifies that the HTTP header of a diagram incites the browser to cache it.
      */
+    @Test
     public void testInvalidUrl() throws IOException {
         final URL url = new URL(getServerUrl() + "/proxy/invalidURL");
         final HttpURLConnection conn = (HttpURLConnection)url.openConnection();
         // Analyze response
         // Check if status code is 400
-        assertEquals(
-            "Bad HTTP status received",
-            400,
-            conn.getResponseCode()
-        );
+        Assertions.assertEquals(400, conn.getResponseCode(), "Bad HTTP status received");
         // Check error message
-        assertTrue(
-            "Response is not malformed URL",
-            getContentText(conn.getErrorStream()).contains("URL malformed.")
+        Assertions.assertTrue(
+            getContentText(conn.getErrorStream()).contains("URL malformed."),
+            "Response is not malformed URL"
         );
     }
 

--- a/src/test/java/net/sourceforge/plantuml/servlet/TestProxy.java
+++ b/src/test/java/net/sourceforge/plantuml/servlet/TestProxy.java
@@ -4,6 +4,9 @@ import java.io.IOException;
 import java.net.HttpURLConnection;
 import java.net.URL;
 
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
 import net.sourceforge.plantuml.servlet.utils.WebappTestCase;
 
 
@@ -12,103 +15,104 @@ public class TestProxy extends WebappTestCase {
     /**
      * Verifies the proxified reception of the default Bob and Alice diagram
      */
+    @Test
     public void testDefaultProxy() throws IOException {
         final URL url = new URL(getServerUrl() + "/proxy?src=" + getTestDiagramUrl());
         final HttpURLConnection conn = (HttpURLConnection)url.openConnection();
         // Analyze response
         // Verifies HTTP status code and the Content-Type
-        assertEquals("Bad HTTP status received", 200, conn.getResponseCode());
-        assertEquals(
-            "Response content type is not PNG",
+        Assertions.assertEquals(200, conn.getResponseCode(), "Bad HTTP status received");
+        Assertions.assertEquals(
             "image/png",
-            conn.getContentType().toLowerCase()
+            conn.getContentType().toLowerCase(),
+            "Response content type is not PNG"
         );
         // Get the image and verify its size (~2000 bytes)
         byte[] inMemoryImage = getContentAsBytes(conn);
         int diagramLen = inMemoryImage.length;
-        assertTrue(diagramLen > 2000);
-        assertTrue(diagramLen < 3000);
+        Assertions.assertTrue(diagramLen > 2000);
+        Assertions.assertTrue(diagramLen < 3000);
     }
 
     /**
      * Verifies the proxified reception of the default Bob and Alice diagram with defined format.
      */
+    @Test
     public void testProxyWithFormat() throws IOException {
         final URL url = new URL(getServerUrl() + "/proxy?fmt=svg&src=" + getTestDiagramUrl());
         final HttpURLConnection conn = (HttpURLConnection)url.openConnection();
         // Analyze response
         // Verifies HTTP status code and the Content-Type
-        assertEquals("Bad HTTP status received", 200, conn.getResponseCode());
-        assertEquals(
-            "Response content type is not SVG",
+        Assertions.assertEquals(200, conn.getResponseCode(), "Bad HTTP status received");
+        Assertions.assertEquals(
             "image/svg+xml",
-            conn.getContentType().toLowerCase()
+            conn.getContentType().toLowerCase(),
+            "Response content type is not SVG"
         );
         // Get the content and verify its size
         String diagram = getContentText(conn);
         int diagramLen = diagram.length();
-        assertTrue(diagramLen > 1500);
-        assertTrue(diagramLen < 3000);
+        Assertions.assertTrue(diagramLen > 1500);
+        Assertions.assertTrue(diagramLen < 3000);
     }
 
     /**
      * Verifies the proxified reception of the default Bob and Alice diagram with defined format and format (idx=0).
      */
+    @Test
     public void testProxyWithFormatIdx0() throws IOException {
         final URL url = new URL(getServerUrl() + "/proxy?fmt=svg&idx=0&src=" + getTestDiagramUrl());
         final HttpURLConnection conn = (HttpURLConnection)url.openConnection();
         // Analyze response
         // Verifies HTTP status code and the Content-Type
-        assertEquals("Bad HTTP status received", 200, conn.getResponseCode());
-        assertEquals(
-            "Response content type is not SVG",
+        Assertions.assertEquals(200, conn.getResponseCode(), "Bad HTTP status received");
+        Assertions.assertEquals(
             "image/svg+xml",
-            conn.getContentType().toLowerCase()
+            conn.getContentType().toLowerCase(),
+            "Response content type is not SVG"
         );
         // Get the content and verify its size
         String diagram = getContentText(conn);
         int diagramLen = diagram.length();
-        assertTrue(diagramLen > 1500);
-        assertTrue(diagramLen < 3000);
+        Assertions.assertTrue(diagramLen > 1500);
+        Assertions.assertTrue(diagramLen < 3000);
     }
 
     /**
      * Verifies the proxified reception of the default Bob and Alice diagram with defined format and format (idx=1).
      */
+    @Test
     public void testProxyWithFormatIdx1() throws IOException {
         final URL url = new URL(getServerUrl() + "/proxy?fmt=svg&idx=1&src=" + getTestDiagramUrl());
         final HttpURLConnection conn = (HttpURLConnection)url.openConnection();
         // Analyze response
         // Verifies HTTP status code and the Content-Type
-        assertEquals("Bad HTTP status received", 200, conn.getResponseCode());
-        assertEquals(
-            "Response content type is not SVG",
+        Assertions.assertEquals(200, conn.getResponseCode(), "Bad HTTP status received");
+        Assertions.assertEquals(
             "image/svg+xml",
-            conn.getContentType().toLowerCase()
+            conn.getContentType().toLowerCase(),
+            "Response content type is not SVG"
         );
         // Get the content and verify its size
         String diagram = getContentText(conn);
         int diagramLen = diagram.length();
-        assertTrue(diagramLen > 5000);
-        assertTrue(diagramLen < 6000);
+        Assertions.assertTrue(diagramLen > 5000);
+        Assertions.assertTrue(diagramLen < 6000);
     }
 
     /**
      * Verifies that the HTTP header of a diagram incites the browser to cache it.
      */
+    @Test
     public void testInvalidUrl() throws IOException {
         final URL url = new URL(getServerUrl() + "/proxy?src=invalidURL");
         final HttpURLConnection conn = (HttpURLConnection)url.openConnection();
         // Analyze response, it must be HTTP error 400
-        assertEquals(
-            "Bad HTTP status received",
-            400,
-            conn.getResponseCode()
-        );
+        Assertions.assertEquals(400, conn.getResponseCode(), "Bad HTTP status received");
         // Check error message
-        assertTrue(
-            "Response is not malformed URL",
-            getContentText(conn.getErrorStream()).contains("URL malformed.")
+        Assertions.assertTrue(
+            getContentText(conn.getErrorStream()).contains("URL malformed."),
+            "Response is not malformed URL"
         );
     }
 

--- a/src/test/java/net/sourceforge/plantuml/servlet/TestSVG.java
+++ b/src/test/java/net/sourceforge/plantuml/servlet/TestSVG.java
@@ -8,6 +8,9 @@ import java.net.URL;
 import java.net.URLConnection;
 import java.util.Scanner;
 
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
 import net.sourceforge.plantuml.servlet.utils.TestUtils;
 import net.sourceforge.plantuml.servlet.utils.WebappTestCase;
 
@@ -17,26 +20,28 @@ public class TestSVG extends WebappTestCase {
     /**
      * Verifies the generation of the SVG for the Bob -> Alice sample
      */
+    @Test
     public void testSimpleSequenceDiagram() throws IOException {
         final URL url = new URL(getServerUrl() + "/svg/" + TestUtils.SEQBOB);
         final URLConnection conn = url.openConnection();
         // Analyze response
         // Verifies the Content-Type header
-        assertEquals(
-            "Response content type is not SVG",
+        Assertions.assertEquals(
             "image/svg+xml",
-            conn.getContentType().toLowerCase()
+            conn.getContentType().toLowerCase(),
+            "Response content type is not SVG"
         );
         // Get the content and verify its size
         String diagram = getContentText(conn);
         int diagramLen = diagram.length();
-        assertTrue(diagramLen > 1000);
-        assertTrue(diagramLen < 3000);
+        Assertions.assertTrue(diagramLen > 1000);
+        Assertions.assertTrue(diagramLen < 3000);
     }
 
     /**
      * Verifies the generation of the SVG for the Bob -> Alice sample
      */
+    @Test
     public void testPostedSequenceDiagram() throws IOException {
         final URL url = new URL(getServerUrl() + "/svg");
         final HttpURLConnection conn = (HttpURLConnection)url.openConnection();
@@ -49,27 +54,24 @@ public class TestSVG extends WebappTestCase {
         }
         // Analyze response
         // HTTP response 200
-        assertEquals(
-            "Bad HTTP status received",
-            200,
-            conn.getResponseCode()
-        );
+        Assertions.assertEquals(200, conn.getResponseCode(), "Bad HTTP status received");
         // Verifies the Content-Type header
-        assertEquals(
-            "Response content type is not SVG",
+        Assertions.assertEquals(
             "image/svg+xml",
-            conn.getContentType().toLowerCase()
+            conn.getContentType().toLowerCase(),
+            "Response content type is not SVG"
         );
         // Get the content and verify its size
         String diagram = getContentText(conn.getInputStream());
         int diagramLen = diagram.length();
-        assertTrue(diagramLen > 1000);
-        assertTrue(diagramLen < 3000);
+        Assertions.assertTrue(diagramLen > 1000);
+        Assertions.assertTrue(diagramLen < 3000);
     }
 
     /**
      * Verifies the generation of the SVG for the Bob -> Alice sample
      */
+    @Test
     public void testPostedInvalidSequenceDiagram() throws IOException {
         final URL url = new URL(getServerUrl() + "/svg");
         final HttpURLConnection conn = (HttpURLConnection)url.openConnection();
@@ -82,16 +84,13 @@ public class TestSVG extends WebappTestCase {
         }
         // Analyze response
         // HTTP response 400
-        assertEquals(
-            "Bad HTTP status received",
-            400,
-            conn.getResponseCode()
-        );
+        Assertions.assertEquals(400, conn.getResponseCode(), "Bad HTTP status received");
     }
 
     /**
      * Check the content of the SVG
      */
+    @Test
     public void testSequenceDiagramContent() throws IOException {
         final URL url = new URL(getServerUrl() + "/svg/" + TestUtils.SEQBOB);
         // Analyze response
@@ -112,8 +111,8 @@ public class TestSVG extends WebappTestCase {
                     aliceCounter++;
                 }
             }
-            assertTrue(bobCounter == 2);
-            assertTrue(aliceCounter == 2);
+            Assertions.assertTrue(bobCounter == 2);
+            Assertions.assertTrue(aliceCounter == 2);
         }
     }
 

--- a/src/test/java/net/sourceforge/plantuml/servlet/TestWebUI.java
+++ b/src/test/java/net/sourceforge/plantuml/servlet/TestWebUI.java
@@ -1,7 +1,7 @@
 package net.sourceforge.plantuml.servlet;
 
-import static org.junit.Assert.assertNotEquals;
-
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 import org.openqa.selenium.By;
 import org.openqa.selenium.Dimension;
 import org.openqa.selenium.WebElement;
@@ -15,46 +15,49 @@ public class TestWebUI extends WebappUITestCase {
     /**
      * Verifies that the welcome page has exactly two form with the Bob --> Alice sample
      */
+    @Test
     public void testWelcomePage() {
         driver.get(getServerUrl());
-        assertTrue("UI loading completed", waitUntilUIIsLoaded());
+        Assertions.assertTrue(waitUntilUIIsLoaded(), "UI loading completed");
         // ensure the editor text is correct
         String text = getEditorValue();
-        assertEquals(TestUtils.SEQBOBCODE, text);
+        Assertions.assertEquals(TestUtils.SEQBOBCODE, text);
         // ensure the URL field is correct
         String url = getURLValue();
-        assertTrue(url.endsWith("/png/" + TestUtils.SEQBOB));
+        Assertions.assertTrue(url.endsWith("/png/" + TestUtils.SEQBOB));
         // ensure the generated image is present
         Dimension dim = getImageSize();
-        assertNotEquals(0, dim.getHeight());  // 145
-        assertNotEquals(0, dim.getWidth());   // 134
+        Assertions.assertNotEquals(0, dim.getHeight());  // 145
+        Assertions.assertNotEquals(0, dim.getWidth());   // 134
     }
 
     /**
      * Verifies that the version image is generated
      */
+    @Test
     public void testVersion() {
         driver.get(getServerUrl());
-        assertTrue("UI loading completed", waitUntilUIIsLoaded());
+        Assertions.assertTrue(waitUntilUIIsLoaded(), "UI loading completed");
         // change code and observe result
         setEditorValue(TestUtils.VERSIONCODE);
-        assertTrue("Auto update done", waitUntilAutoRefreshCompleted());
+        Assertions.assertTrue(waitUntilAutoRefreshCompleted(), "Auto update done");
         // ensure the editor text is correct
         String text = getEditorValue();
-        assertEquals(TestUtils.VERSIONCODE, text);
+        Assertions.assertEquals(TestUtils.VERSIONCODE, text);
         // ensure the URL field is correct
         String url = getURLValue();
-        assertTrue(url.endsWith("/png/" + TestUtils.VERSION));
+        Assertions.assertTrue(url.endsWith("/png/" + TestUtils.VERSION));
         // ensure the generated image is present
         Dimension dim = getImageSize();
-        assertNotEquals(0, dim.getHeight());  // 242
-        assertNotEquals(0, dim.getWidth());   // 472
+        Assertions.assertNotEquals(0, dim.getHeight());  // 242
+        Assertions.assertNotEquals(0, dim.getWidth());   // 472
     }
 
     // /**
     //  * Verifies that when the UML text is empty, ...
     //  * old behavior: default page and image is generated
     //  */
+    // @Test
     // public void testEmptyText() {
     //     // ...
     // }
@@ -63,6 +66,7 @@ public class TestWebUI extends WebappUITestCase {
     //  * Verifies that when the encoded URL is empty, ...
     //  * old behavior: default page and image is generated
     //  */
+    // @Test
     // public void testEmptyUrl() {
     //     // ...
     // }
@@ -70,69 +74,72 @@ public class TestWebUI extends WebappUITestCase {
     /**
      * Verifies that a ditaa diagram is generated
      */
+    @Test
     public void testDitaaText() {
         driver.get(getServerUrl());
-        assertTrue("UI loading completed", waitUntilUIIsLoaded());
+        Assertions.assertTrue(waitUntilUIIsLoaded(), "UI loading completed");
         // change code and observe result
         setEditorValue("@startditaa \n*--> \n@endditaa");
-        assertTrue("Auto update done", waitUntilAutoRefreshCompleted());
+        Assertions.assertTrue(waitUntilAutoRefreshCompleted(), "Auto update done");
         // ensure the editor text is correct
         String text = getEditorValue();
-        assertEquals("@startditaa \n*--> \n@endditaa", text);
+        Assertions.assertEquals("@startditaa \n*--> \n@endditaa", text);
         // ensure the URL field is correct
         String url = getURLValue();
-        assertTrue(url.endsWith("/png/SoWkIImgISaiIKnKuDBIrRLJu798pKi12m00"));
+        Assertions.assertTrue(url.endsWith("/png/SoWkIImgISaiIKnKuDBIrRLJu798pKi12m00"));
         // ensure the generated image is present
         Dimension dim = getImageSize();
-        assertNotEquals(0, dim.getHeight());
-        assertNotEquals(0, dim.getWidth());
+        Assertions.assertNotEquals(0, dim.getHeight());
+        Assertions.assertNotEquals(0, dim.getWidth());
     }
 
     /**
      * Verifies that an image map is produced if the diagram contains a link
      */
+    @Test
     public void testImageMap() {
         driver.get(getServerUrl());
-        assertTrue("UI loading completed", waitUntilUIIsLoaded());
+        Assertions.assertTrue(waitUntilUIIsLoaded(), "UI loading completed");
         // change code and observe result
         setEditorValue("@startuml\nBob -> Alice : [[http://yahoo.com]] Hello\n@enduml");
-        assertTrue("Auto update done", waitUntilAutoRefreshCompleted());
+        Assertions.assertTrue(waitUntilAutoRefreshCompleted(), "Auto update done");
         // ensure the editor text is correct
         String text = getEditorValue();
-        assertEquals("@startuml\nBob -> Alice : [[http://yahoo.com]] Hello\n@enduml", text);
+        Assertions.assertEquals("@startuml\nBob -> Alice : [[http://yahoo.com]] Hello\n@enduml", text);
         // ensure the URL field is correct
         String url = getURLValue();
-        assertTrue(url.endsWith("/png/SyfFKj2rKt3CoKnELR1IY8xEA2afiDBNhqpCoC_NIyxFZOrLy4ZDoSa70000"));
+        Assertions.assertTrue(url.endsWith("/png/SyfFKj2rKt3CoKnELR1IY8xEA2afiDBNhqpCoC_NIyxFZOrLy4ZDoSa70000"));
         // ensure the generated image is present
         Dimension dim = getImageSize();
-        assertNotEquals(0, dim.getHeight());
-        assertNotEquals(0, dim.getWidth());
+        Assertions.assertNotEquals(0, dim.getHeight());
+        Assertions.assertNotEquals(0, dim.getWidth());
         // ensure the image map is present
         WebElement map = getImageMap();
-        assertNotNull(map);
-        assertEquals(1, Integer.parseInt(map.getAttribute("childElementCount")));
+        Assertions.assertNotNull(map);
+        Assertions.assertEquals(1, Integer.parseInt(map.getAttribute("childElementCount")));
         // ensure the map button is visible
         WebElement btnMap = driver.findElement(By.id("map-diagram-link"));
-        assertTrue(btnMap.isDisplayed());
+        Assertions.assertTrue(btnMap.isDisplayed());
     }
 
     /**
      * Verifies that when the encoded source is specified as an URL parameter
      * the diagram is displayed and the source is decoded
      */
+    @Test
     public void testUrlParameter() {
         driver.get(getServerUrl() + "/form?url=" + TestUtils.SEQBOB);
-        assertTrue("UI loading completed", waitUntilUIIsLoaded());
+        Assertions.assertTrue(waitUntilUIIsLoaded(), "UI loading completed");
         // ensure the editor text is correct
         String text = getEditorValue();
-        assertEquals(TestUtils.SEQBOBCODE, text);
+        Assertions.assertEquals(TestUtils.SEQBOBCODE, text);
         // ensure the URL field is correct
         String url = getURLValue();
-        assertTrue(url.endsWith("/png/" + TestUtils.SEQBOB));
+        Assertions.assertTrue(url.endsWith("/png/" + TestUtils.SEQBOB));
         // ensure the generated image is present
         Dimension dim = getImageSize();
-        assertNotEquals(0, dim.getHeight());
-        assertNotEquals(0, dim.getWidth());
+        Assertions.assertNotEquals(0, dim.getHeight());
+        Assertions.assertNotEquals(0, dim.getWidth());
     }
 
     /**
@@ -147,28 +154,29 @@ public class TestWebUI extends WebappUITestCase {
      * newpage
      * Bob <- Alice : bye
      */
+    @Test
     public void testIndexPage() {
         driver.get(
             getServerUrl() + "/uml/1/" +
             "SyfFKj2rKt3CoKnELR1Io4ZDoSddoaijBqXCJ-Lo0ahQwA99Eg7go4ajKIzMA4dCoKPNdfHQKf9Qf92NNuAknqQjA34ppquXgJ8Lbrr0AG00"
         );
-        assertTrue("UI loading completed", waitUntilUIIsLoaded());
+        Assertions.assertTrue(waitUntilUIIsLoaded(), "UI loading completed");
         // ensure the editor text is correct
         String text = getEditorValue();
-        assertEquals(
+        Assertions.assertEquals(
             "@startuml\nBob -> Alice : hello\nnewpage\nBob <- Alice : hello\nBob -> Alice : let's talk\nBob <- Alice : better not\nBob -> Alice : <&rain> bye\nnewpage\nBob <- Alice : bye\n@enduml",
             text
         );
         // ensure the URL field is correct
         String url = getURLValue();
-        assertTrue(url.endsWith("/png/1/SyfFKj2rKt3CoKnELR1Io4ZDoSddoaijBqXCJ-Lo0ahQwA99Eg7go4ajKIzMA4dCoKPNdfHQKf9Qf92NNuAknqQjA34ppquXgJ8Lbrr0AG00"));
+        Assertions.assertTrue(url.endsWith("/png/1/SyfFKj2rKt3CoKnELR1Io4ZDoSddoaijBqXCJ-Lo0ahQwA99Eg7go4ajKIzMA4dCoKPNdfHQKf9Qf92NNuAknqQjA34ppquXgJ8Lbrr0AG00"));
         // ensure the generated image is present
         Dimension dim = getImageSize();
-        assertNotEquals(0, dim.getHeight());
-        assertNotEquals(0, dim.getWidth());
+        Assertions.assertNotEquals(0, dim.getHeight());
+        Assertions.assertNotEquals(0, dim.getWidth());
         // ensure the correct index was generated
-        assertTrue(dim.getHeight() > 200);  // 222
-        assertTrue(dim.getHeight() < 250);  // 222
+        Assertions.assertTrue(dim.getHeight() > 200);  // 222
+        Assertions.assertTrue(dim.getHeight() < 250);  // 222
     }
 
     /**
@@ -183,27 +191,28 @@ public class TestWebUI extends WebappUITestCase {
      * newpage
      * Bob <- Alice : bye
      */
+    @Test
     public void testIndexPageWithNoDefinedIndex() {
         driver.get(
             getServerUrl() + "/uml/" +
             "SyfFKj2rKt3CoKnELR1Io4ZDoSddoaijBqXCJ-Lo0ahQwA99Eg7go4ajKIzMA4dCoKPNdfHQKf9Qf92NNuAknqQjA34ppquXgJ8Lbrr0AG00"
         );
-        assertTrue("UI loading completed", waitUntilUIIsLoaded());
+        Assertions.assertTrue(waitUntilUIIsLoaded(), "UI loading completed");
         // ensure the editor text is correct
         String text = getEditorValue();
-        assertEquals(
+        Assertions.assertEquals(
             "@startuml\nBob -> Alice : hello\nnewpage\nBob <- Alice : hello\nBob -> Alice : let's talk\nBob <- Alice : better not\nBob -> Alice : <&rain> bye\nnewpage\nBob <- Alice : bye\n@enduml",
             text
         );
         // ensure the URL field is correct
         String url = getURLValue();
-        assertTrue(url.endsWith("/png/SyfFKj2rKt3CoKnELR1Io4ZDoSddoaijBqXCJ-Lo0ahQwA99Eg7go4ajKIzMA4dCoKPNdfHQKf9Qf92NNuAknqQjA34ppquXgJ8Lbrr0AG00"));
+        Assertions.assertTrue(url.endsWith("/png/SyfFKj2rKt3CoKnELR1Io4ZDoSddoaijBqXCJ-Lo0ahQwA99Eg7go4ajKIzMA4dCoKPNdfHQKf9Qf92NNuAknqQjA34ppquXgJ8Lbrr0AG00"));
         // ensure the generated image is present
         Dimension dim = getImageSize();
-        assertNotEquals(0, dim.getHeight());
-        assertNotEquals(0, dim.getWidth());
+        Assertions.assertNotEquals(0, dim.getHeight());
+        Assertions.assertNotEquals(0, dim.getWidth());
         // ensure the correct index was generated
-        assertTrue(dim.getHeight() > 100);  // 132
-        assertTrue(dim.getHeight() < 150);  // 132
+        Assertions.assertTrue(dim.getHeight() > 100);  // 132
+        Assertions.assertTrue(dim.getHeight() < 150);  // 132
     }
 }

--- a/src/test/java/net/sourceforge/plantuml/servlet/utils/WebappTestCase.java
+++ b/src/test/java/net/sourceforge/plantuml/servlet/utils/WebappTestCase.java
@@ -7,15 +7,17 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.net.URL;
 import java.net.URLConnection;
+import java.util.stream.Collectors;
 
-import junit.framework.TestCase;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 
 import net.sourceforge.plantuml.servlet.server.EmbeddedJettyServer;
 import net.sourceforge.plantuml.servlet.server.ExternalServer;
 import net.sourceforge.plantuml.servlet.server.ServerUtils;
 
 
-public abstract class WebappTestCase extends TestCase {
+public abstract class WebappTestCase {
 
     private final ServerUtils serverUtils;
 
@@ -34,12 +36,12 @@ public abstract class WebappTestCase extends TestCase {
         serverUtils = new EmbeddedJettyServer();
     }
 
-    @Override
+    @BeforeEach
     public void setUp() throws Exception {
         serverUtils.startServer();
     }
 
-    @Override
+    @AfterEach
     public void tearDown() throws Exception {
         serverUtils.stopServer();
     }
@@ -67,17 +69,8 @@ public abstract class WebappTestCase extends TestCase {
     }
 
     public String getContentText(final InputStream stream) throws IOException {
-        try (
-            final InputStreamReader isr = new InputStreamReader(stream);
-            final BufferedReader br = new BufferedReader(isr);
-        ) {
-            String line;
-            StringBuffer sb = new StringBuffer();
-            while ((line = br.readLine()) != null) {
-                sb.append(line);
-                sb.append("\n");
-            }
-            return sb.toString().trim();
+        try (final BufferedReader br = new BufferedReader(new InputStreamReader(stream))) {
+            return br.lines().collect(Collectors.joining("\n"));
         }
     }
 

--- a/src/test/java/net/sourceforge/plantuml/servlet/utils/WebappUITestCase.java
+++ b/src/test/java/net/sourceforge/plantuml/servlet/utils/WebappUITestCase.java
@@ -2,6 +2,8 @@ package net.sourceforge.plantuml.servlet.utils;
 
 import java.time.Duration;
 
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.openqa.selenium.By;
 import org.openqa.selenium.Dimension;
 import org.openqa.selenium.JavascriptExecutor;
@@ -16,14 +18,14 @@ public abstract class WebappUITestCase extends WebappTestCase {
     public WebDriver driver;
     public JavascriptExecutor js;
 
-    @Override
+    @BeforeEach
     public void setUp() throws Exception {
         super.setUp();
         driver = JUnitWebDriver.getDriver();
         js = (JavascriptExecutor)driver;
     }
 
-    @Override
+    @AfterEach
     public void tearDown() throws Exception {
         driver.close();
         super.tearDown();


### PR DESCRIPTION
Short: update maven artifacts and docker base image (as well as reduce there image size).
This PR also close #253 that mentioned that the current used jetty version is vulnerable.

### Update maven artifacts
- `checkstyle` stopped supporting jdk8 with version 10.0.0  
  https://checkstyle.org/releasenotes.html#Release_10.0
- PDF dependency was missing in the jdk8 pom file
  * Maybe it would be better to creating a parent pom? In that case all PlantUML dependencies could be in the parent pom and one would only have to maintain the parent pom file.
  * Why doesn't exist any PDF test?
- add rule to ignore version update hint with `-dev` followed by a dot and date (e.g. `0.37.0-dev.20230308`)
- migration from JUnit4 to JUnit5

### Docker
There were same base image and naming changes for the jetty and tomcat images plantuml-server uses. Therefore, plantuml-server uses a rather old and vulnerable image, since there are no updates according to the old naming scheme.

- update base images for jetty and tomcat
- add a alpine version for jetty  
  Note:
    * tomcat has no official alpine version => no plantuml alpine tomcat image
    * jetty alpine version is only available for people who build it by there own
- add `autoremove` and `clean` commands after `graphviz` installation. This reduces the images by about ~280 MB.
  * Jetty: 704 MB -> 413 MB (reduced by ~40%)
  * Tomcat: 905 MB -> 632 MB (reduced by ~30%)