### PR TITLE
Docker: always build latest `graphviz` release

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -17,3 +17,6 @@ trim_trailing_whitespace = false
 
 [*.puml]
 insert_final_newline = false
+
+[{Dockerfile,Dockerfile.*}]
+indent_size = 4

--- a/Dockerfile.jetty
+++ b/Dockerfile.jetty
@@ -27,17 +27,19 @@ RUN apt-get update && \
     /generate-jetty-start.sh
 
 # Build Graphviz from source because there are no binary distributions for recent versions
-ARG GRAPHVIZ_VERSION=8.0.2
+ARG GRAPHVIZ_VERSION
 ARG GRAPHVIZ_BUILD_DIR=/tmp/graphiz-build
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
         build-essential \
+        jq \
         libexpat1-dev \
         libgd-dev \
         zlib1g-dev \
         && \
     mkdir -p $GRAPHVIZ_BUILD_DIR && \
     cd $GRAPHVIZ_BUILD_DIR && \
+    GRAPHVIZ_VERSION=${GRAPHVIZ_VERSION:-$(curl -s https://gitlab.com/api/v4/projects/4207231/releases/ | jq -r '.[] | .name' | sort -V -r | head -1)} && \
     curl -o graphviz.tar.gz https://gitlab.com/api/v4/projects/4207231/packages/generic/graphviz-releases/${GRAPHVIZ_VERSION}/graphviz-${GRAPHVIZ_VERSION}.tar.gz && \
     tar -xzf graphviz.tar.gz && \
     cd graphviz-$GRAPHVIZ_VERSION && \
@@ -46,6 +48,7 @@ RUN apt-get update && \
     make install && \
     apt-get remove -y \
         build-essential \
+        jq \
         libexpat1-dev \
         libgd-dev \
         zlib1g-dev \

--- a/Dockerfile.jetty-alpine
+++ b/Dockerfile.jetty-alpine
@@ -25,16 +25,18 @@ RUN apk add --no-cache \
     /generate-jetty-start.sh
 
 #RUN apk add --no-cache graphviz
-ARG GRAPHVIZ_VERSION=8.0.2
+ARG GRAPHVIZ_VERSION
 ARG GRAPHVIZ_BUILD_DIR=/tmp/graphiz-build
 RUN apk add --no-cache \
         g++ \
+        jq \
         libexpat \
         make \
         zlib \
         && \
     mkdir -p $GRAPHVIZ_BUILD_DIR && \
     cd $GRAPHVIZ_BUILD_DIR && \
+    GRAPHVIZ_VERSION=${GRAPHVIZ_VERSION:-$(curl -s https://gitlab.com/api/v4/projects/4207231/releases/ | jq -r '.[] | .name' | sort -V -r | head -1)} && \
     curl -o graphviz.tar.gz https://gitlab.com/api/v4/projects/4207231/packages/generic/graphviz-releases/${GRAPHVIZ_VERSION}/graphviz-${GRAPHVIZ_VERSION}.tar.gz && \
     tar -xzf graphviz.tar.gz && \
     cd graphviz-$GRAPHVIZ_VERSION && \
@@ -43,6 +45,7 @@ RUN apk add --no-cache \
     make install && \
     apk del --no-cache \
         g++ \
+        jq \
         libexpat \
         make \
         zlib \

--- a/Dockerfile.tomcat
+++ b/Dockerfile.tomcat
@@ -19,17 +19,19 @@ RUN apt-get update && \
     rm -rf /var/lib/apt/lists/*
 
 # Build Graphviz from source because there are no binary distributions for recent versions
-ARG GRAPHVIZ_VERSION=8.0.2
+ARG GRAPHVIZ_VERSION
 ARG GRAPHVIZ_BUILD_DIR=/tmp/graphiz-build
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
         build-essential \
+        jq \
         libexpat1-dev \
         libgd-dev \
         zlib1g-dev \
         && \
     mkdir -p $GRAPHVIZ_BUILD_DIR && \
     cd $GRAPHVIZ_BUILD_DIR && \
+    GRAPHVIZ_VERSION=${GRAPHVIZ_VERSION:-$(curl -s https://gitlab.com/api/v4/projects/4207231/releases/ | jq -r '.[] | .name' | sort -V -r | head -1)} && \
     curl -o graphviz.tar.gz https://gitlab.com/api/v4/projects/4207231/packages/generic/graphviz-releases/${GRAPHVIZ_VERSION}/graphviz-${GRAPHVIZ_VERSION}.tar.gz && \
     tar -xzf graphviz.tar.gz && \
     cd graphviz-$GRAPHVIZ_VERSION && \
@@ -38,6 +40,7 @@ RUN apt-get update && \
     make install && \
     apt-get remove -y \
         build-essential \
+        jq \
         libexpat1-dev \
         libgd-dev \
         zlib1g-dev \


### PR DESCRIPTION
Currently, every now and then there is a PR that sets the default graphviz version within Dockerfiles to the latest version.

With this PR the docker container will always/automatically use the latest graphviz release if the version was not set manually via the docker build argument `GRAPHVIZ_VERSION`.

close #150 who ased for a graphviz version update (way back in the past :smile:)

----

If somebody wants to review the PR here some note:

If not set as build arg fetch latest version of graphviz based on their release name by default.
An alternative would be to use `tag_name`.

Also, to avoid the overhead of getting all kinds of relase data, GitLabs GraphQL interface could be used.
```bash
curl -s \
  -H "Content-Type:application/json" \
  -d '{"query": "{project(fullPath:\"graphviz/graphviz\"){releases(first:5,sort:RELEASED_AT_DESC){nodes{name}}}}"}' \
  "https://gitlab.com/api/graphql" \
| jq -r '.data.project.releases.nodes[].name' | sort -V -r | head -n 1
```
In GraphQL the alternative to `name` would be `tagName`.

These are possible changes for the future if somebody is unhappy with the current solution. But in my opinion this is not really necessary.