### PR TITLE
fix: PDF servlet

### DIFF
--- a/pom.jdk8.xml
+++ b/pom.jdk8.xml
@@ -74,7 +74,7 @@
     <!-- Testing -->
     <junit.version>5.9.3</junit.version>
     <junit-suite.version>1.9.3</junit-suite.version>
-    <selenium.version>4.9.0</selenium.version>
+    <selenium.version>4.9.1</selenium.version>
     <selenium-webdrivermanager.version>5.3.2</selenium-webdrivermanager.version>
     <commons-io.version>2.11.0</commons-io.version>
     <jetty-server.version>${jetty.version}</jetty-server.version>
@@ -86,7 +86,7 @@
     <maven-resources-plugin.version>3.3.1</maven-resources-plugin.version>
     <maven-compiler-plugin.version>3.11.0</maven-compiler-plugin.version>
     <versions-maven-plugin.version>2.15.0</versions-maven-plugin.version>
-    <maven-surefire-plugin.version>3.0.0</maven-surefire-plugin.version>
+    <maven-surefire-plugin.version>3.1.0</maven-surefire-plugin.version>
     <maven-war-plugin.version>3.3.2</maven-war-plugin.version>
     <maven-install-plugin.version>3.1.1</maven-install-plugin.version>
     <maven-deploy-plugin.version>3.1.1</maven-deploy-plugin.version>
@@ -108,11 +108,13 @@
       <groupId>net.sourceforge.plantuml</groupId>
       <artifactId>plantuml</artifactId>
       <version>${plantuml.version}</version>
+      <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>org.webjars.npm</groupId>
       <artifactId>monaco-editor</artifactId>
       <version>${monaco-editor.version}</version>
+      <scope>runtime</scope>
     </dependency>
     <dependency>
       <groupId>jakarta.servlet</groupId>
@@ -153,31 +155,44 @@
       <groupId>org.scilab.forge</groupId>
       <artifactId>jlatexmath</artifactId>
       <version>${jlatexmath.version}</version>
+      <scope>runtime</scope>
     </dependency>
     <dependency>
       <groupId>org.scilab.forge</groupId>
       <artifactId>jlatexmath-font-greek</artifactId>
       <version>${jlatexmath-font-greek.version}</version>
+      <scope>runtime</scope>
     </dependency>
     <dependency>
       <groupId>org.scilab.forge</groupId>
       <artifactId>jlatexmath-font-cyrillic</artifactId>
       <version>${jlatexmath-font-cyrillic.version}</version>
+      <scope>runtime</scope>
     </dependency>
-    <!-- PDF -->
+    <!-- PDF
+      PlantUMLs PDF generation requires:
+      - batik-dom
+      - batik-svgrasterizer (includes batik-dom)
+      - batik-svggen
+      - fop
+    -->
     <dependency>
-      <!-- batik-all generally tends to provide duplicate resources on the classpath -->
       <groupId>org.apache.xmlgraphics</groupId>
-      <artifactId>batik-all</artifactId>
+      <artifactId>batik-svgrasterizer</artifactId>
       <version>${batik-all.version}</version>
-      <type>pom</type>
+      <scope>runtime</scope>
     </dependency>
     <dependency>
-      <!-- fop generally tends to provide duplicate resources on the classpath -->
+      <groupId>org.apache.xmlgraphics</groupId>
+      <artifactId>batik-svggen</artifactId>
+      <version>${batik-all.version}</version>
+      <scope>runtime</scope>
+    </dependency>
+    <dependency>
       <groupId>org.apache.xmlgraphics</groupId>
       <artifactId>fop</artifactId>
       <version>${fop.version}</version>
-      <type>pom</type>
+      <scope>runtime</scope>
     </dependency>
 
     <!-- Testing -->
@@ -203,12 +218,6 @@
       <groupId>io.github.bonigarcia</groupId>
       <artifactId>webdrivermanager</artifactId>
       <version>${selenium-webdrivermanager.version}</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>commons-io</groupId>
-      <artifactId>commons-io</artifactId>
-      <version>${commons-io.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -74,7 +74,7 @@
     <!-- Testing -->
     <junit.version>5.9.3</junit.version>
     <junit-suite.version>1.9.3</junit-suite.version>
-    <selenium.version>4.9.0</selenium.version>
+    <selenium.version>4.9.1</selenium.version>
     <selenium-webdrivermanager.version>5.3.2</selenium-webdrivermanager.version>
     <commons-io.version>2.11.0</commons-io.version>
     <jetty-server.version>${jetty.version}</jetty-server.version>
@@ -86,7 +86,7 @@
     <maven-resources-plugin.version>3.3.1</maven-resources-plugin.version>
     <maven-compiler-plugin.version>3.11.0</maven-compiler-plugin.version>
     <versions-maven-plugin.version>2.15.0</versions-maven-plugin.version>
-    <maven-surefire-plugin.version>3.0.0</maven-surefire-plugin.version>
+    <maven-surefire-plugin.version>3.1.0</maven-surefire-plugin.version>
     <maven-war-plugin.version>3.3.2</maven-war-plugin.version>
     <maven-install-plugin.version>3.1.1</maven-install-plugin.version>
     <maven-deploy-plugin.version>3.1.1</maven-deploy-plugin.version>
@@ -108,11 +108,13 @@
       <groupId>net.sourceforge.plantuml</groupId>
       <artifactId>plantuml</artifactId>
       <version>${plantuml.version}</version>
+      <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>org.webjars.npm</groupId>
       <artifactId>monaco-editor</artifactId>
       <version>${monaco-editor.version}</version>
+      <scope>runtime</scope>
     </dependency>
     <dependency>
       <groupId>org.eclipse.jetty</groupId>
@@ -131,31 +133,44 @@
       <groupId>org.scilab.forge</groupId>
       <artifactId>jlatexmath</artifactId>
       <version>${jlatexmath.version}</version>
+      <scope>runtime</scope>
     </dependency>
     <dependency>
       <groupId>org.scilab.forge</groupId>
       <artifactId>jlatexmath-font-greek</artifactId>
       <version>${jlatexmath-font-greek.version}</version>
+      <scope>runtime</scope>
     </dependency>
     <dependency>
       <groupId>org.scilab.forge</groupId>
       <artifactId>jlatexmath-font-cyrillic</artifactId>
       <version>${jlatexmath-font-cyrillic.version}</version>
+      <scope>runtime</scope>
     </dependency>
-    <!-- PDF -->
+    <!-- PDF
+      PlantUMLs PDF generation requires:
+      - batik-dom
+      - batik-svgrasterizer (includes batik-dom)
+      - batik-svggen
+      - fop
+    -->
     <dependency>
-      <!-- batik-all generally tends to provide duplicate resources on the classpath -->
       <groupId>org.apache.xmlgraphics</groupId>
-      <artifactId>batik-all</artifactId>
+      <artifactId>batik-svgrasterizer</artifactId>
       <version>${batik-all.version}</version>
-      <type>pom</type>
+      <scope>runtime</scope>
     </dependency>
     <dependency>
-      <!-- fop generally tends to provide duplicate resources on the classpath -->
+      <groupId>org.apache.xmlgraphics</groupId>
+      <artifactId>batik-svggen</artifactId>
+      <version>${batik-all.version}</version>
+      <scope>runtime</scope>
+    </dependency>
+    <dependency>
       <groupId>org.apache.xmlgraphics</groupId>
       <artifactId>fop</artifactId>
       <version>${fop.version}</version>
-      <type>pom</type>
+      <scope>runtime</scope>
     </dependency>
 
    <!-- Testing -->
@@ -181,12 +196,6 @@
       <groupId>io.github.bonigarcia</groupId>
       <artifactId>webdrivermanager</artifactId>
       <version>${selenium-webdrivermanager.version}</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>commons-io</groupId>
-      <artifactId>commons-io</artifactId>
-      <version>${commons-io.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/src/main/java/net/sourceforge/plantuml/servlet/DiagramResponse.java
+++ b/src/main/java/net/sourceforge/plantuml/servlet/DiagramResponse.java
@@ -29,10 +29,7 @@ import java.io.FileReader;
 import java.io.IOException;
 import java.io.PrintWriter;
 import java.util.ArrayList;
-import java.util.Collections;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
@@ -60,10 +57,6 @@ import net.sourceforge.plantuml.version.Version;
 public class DiagramResponse {
 
     /**
-     * {@link FileFormat} to http content type mapping.
-     */
-    private static final Map<FileFormat, String> CONTENT_TYPE;
-    /**
      * X-Powered-By http header value included in every response by default.
      */
     private static final String POWERED_BY = "PlantUML Version " + Version.versionString();
@@ -75,13 +68,6 @@ public class DiagramResponse {
         if ("true".equalsIgnoreCase(System.getenv("ALLOW_PLANTUML_INCLUDE"))) {
             OptionFlags.ALLOW_INCLUDE = true;
         }
-        CONTENT_TYPE = Collections.unmodifiableMap(new HashMap<FileFormat, String>() {{
-            put(FileFormat.PNG, "image/png");
-            put(FileFormat.SVG, "image/svg+xml");
-            put(FileFormat.EPS, "application/postscript");
-            put(FileFormat.UTXT, "text/plain;charset=UTF-8");
-            put(FileFormat.BASE64, "text/plain; charset=x-user-defined");
-        }});
     }
 
     /**
@@ -282,7 +268,7 @@ public class DiagramResponse {
      * @return response content type
      */
     private String getContentType() {
-        return CONTENT_TYPE.get(format);
+        return format.getMimeType();
     }
 
 }

--- a/src/main/java/net/sourceforge/plantuml/servlet/ProxyServlet.java
+++ b/src/main/java/net/sourceforge/plantuml/servlet/ProxyServlet.java
@@ -91,7 +91,6 @@ public class ProxyServlet extends HttpServlet {
         try {
             srcUrl = new URL(source);
         } catch (MalformedURLException mue) {
-            mue.printStackTrace();
             response.sendError(HttpServletResponse.SC_BAD_REQUEST, "URL malformed.");
             return;
         }

--- a/src/test/java/net/sourceforge/plantuml/servlet/TestPDF.java
+++ b/src/test/java/net/sourceforge/plantuml/servlet/TestPDF.java
@@ -1,0 +1,38 @@
+package net.sourceforge.plantuml.servlet;
+
+import java.io.IOException;
+import java.net.HttpURLConnection;
+import java.net.URL;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import net.sourceforge.plantuml.servlet.utils.TestUtils;
+import net.sourceforge.plantuml.servlet.utils.WebappTestCase;
+
+
+public class TestPDF extends WebappTestCase {
+
+    /**
+     * Verifies the generation of the PDF for the Bob -> Alice sample
+     */
+    @Test
+    public void testSimpleSequenceDiagram() throws IOException {
+        final URL url = new URL(getServerUrl() + "/pdf/" + TestUtils.SEQBOB);
+        final HttpURLConnection conn = (HttpURLConnection)url.openConnection();
+        // Analyze response
+        // Verifies HTTP status code and the Content-Type
+        Assertions.assertEquals(200, conn.getResponseCode(), "Bad HTTP status received");
+        Assertions.assertEquals(
+            "application/pdf",
+            conn.getContentType().toLowerCase(),
+            "Response content type is not PDF"
+        );
+        // Get the content and verify its size
+        String diagram = getContentText(conn);
+        int diagramLen = diagram.length();
+        Assertions.assertTrue(diagramLen > 1500);
+        Assertions.assertTrue(diagramLen < 2000);
+    }
+
+}


### PR DESCRIPTION
Since the update of `bastik` the PDF servlet didn't work anymore.

Problems:
- No PDF UnitTest existed
- Pom dependency `org.apache.xmlgraphics.batik-all` change nearly every dependency to `optional` starting with version `1.15`, hence some important dependencies like the SVG converter were missing
- `DiagramResponse.CONTENT_TYPE` had no mime type value for PDF

Changes:
- add PDF UnitTest
- remove `batik-all` dependency and only include the dependencies PlantUML requires for the PDF generation:
  * batik-dom
  * batik-svgrasterizer (includes batik-dom)
  * batik-svggen
  * fop
- remove own `DiagramResponse.CONTENT_TYPE` mapping and use `FileFormat.getMimeType()`

close #285