### PR TITLE
Add dependency tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -69,7 +69,7 @@ jobs:
         run: sleep 5s
 
       - name: Run tests against "mvn jetty:run" server
-        run: mvn --batch-mode test -DskipTests=false -DargLine="-Dsystem.test.server=http://localhost:8080/plantuml"
+        run: mvn --batch-mode test -DskipTests=false -Dgroups=\!graphviz-test -DargLine="-Dsystem.test.server=http://localhost:8080/plantuml"
 
   test-mvn-livecycle:
     runs-on: ubuntu-latest
@@ -131,7 +131,7 @@ jobs:
           cache: "maven"
 
       - name: Run tests against jetty embedded server
-        run: mvn --batch-mode clean test -DskipTests=false
+        run: mvn --batch-mode clean test -DskipTests=false -Dgroups=\!graphviz-test
 
   test-mvn-jetty-run:
     runs-on: ubuntu-latest
@@ -161,7 +161,7 @@ jobs:
         run: sleep 20s
 
       - name: Run tests against "mvn jetty:run" server
-        run: mvn --batch-mode test -DskipTests=false -DargLine="-Dsystem.test.server=http://localhost:8080/plantuml"
+        run: mvn --batch-mode test -DskipTests=false -Dgroups=\!graphviz-test -DargLine="-Dsystem.test.server=http://localhost:8080/plantuml"
 
   test-jetty-runner:
     runs-on: ubuntu-latest
@@ -191,7 +191,7 @@ jobs:
         run: sleep 5s
 
       - name: Run tests against "mvn jetty:run" server
-        run: mvn --batch-mode test -DskipTests=false -DargLine="-Dsystem.test.server=http://localhost:8080/plantuml"
+        run: mvn --batch-mode test -DskipTests=false -Dgroups=\!graphviz-test -DargLine="-Dsystem.test.server=http://localhost:8080/plantuml"
 
   test-jetty:
     runs-on: ubuntu-latest

--- a/pom.xml
+++ b/pom.xml
@@ -62,6 +62,13 @@
     <plantuml.version>1.2023.7</plantuml.version>
     <!-- Please keep the jetty version identical with the docker image -->
     <jetty.version>11.0.15</jetty.version>
+    <!--
+      While changing the version, please update the versions in the following files as well:
+      - src/main/webapp/components/app-head.jsp (script import)
+      - src/main/webapp/components/editor/editor.js : loadMonacoCodeEditorAsync (require.config)
+      - src/test/java/net/sourceforge/plantuml/servlet/TestDependencies.java : testMonacoEditorWebJar (JUnit Test)
+      as well as inside the pom.jdk8.xml :D
+    -->
     <monaco-editor.version>0.36.1</monaco-editor.version>
 
     <!-- dependencies -->

--- a/src/test/java/net/sourceforge/plantuml/servlet/TestDependencies.java
+++ b/src/test/java/net/sourceforge/plantuml/servlet/TestDependencies.java
@@ -1,0 +1,53 @@
+package net.sourceforge.plantuml.servlet;
+
+import java.io.IOException;
+import java.net.HttpURLConnection;
+import java.net.URL;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import net.sourceforge.plantuml.servlet.utils.TestUtils;
+import net.sourceforge.plantuml.servlet.utils.WebappTestCase;
+
+
+public class TestDependencies extends WebappTestCase {
+
+    /**
+     * Verifies that Graphviz is installed and can be found
+     */
+    @Test
+    @Tag("graphviz-test")
+    public void testGraphviz() throws IOException {
+        final URL url = new URL(getServerUrl() + "/txt/" + TestUtils.VERSION);
+        final HttpURLConnection conn = (HttpURLConnection)url.openConnection();
+        // Analyze response
+        // Verifies HTTP status code and the Content-Type
+        Assertions.assertEquals(200, conn.getResponseCode(), "Bad HTTP status received");
+        Assertions.assertEquals(
+            "text/plain;charset=utf-8",
+            conn.getContentType().toLowerCase(),
+            "Response content type is not TEXT PLAIN or UTF-8"
+        );
+        // Get the content and check installation status
+        String diagram = getContentText(conn);
+        Assertions.assertTrue(
+            diagram.contains("Installation seems OK. File generation OK"),
+            "Version diagram was:\n" + diagram
+        );
+    }
+
+    /**
+     * Verifies that the Monaco Editor webjar can be loaded
+     */
+    @Test
+    public void testMonacoEditorWebJar() throws IOException {
+        final URL url = new URL(getServerUrl() + "/webjars/monaco-editor/0.36.1/min/vs/loader.js");
+        final HttpURLConnection conn = (HttpURLConnection)url.openConnection();
+        // Analyze response
+        // Verifies HTTP status code and the Content-Type
+        Assertions.assertEquals(200, conn.getResponseCode(), "Bad HTTP status received");
+    }
+
+}


### PR DESCRIPTION
- add `testGraphviz`: request `version` as AsciiArt and search for "Installation seems OK. File generation OK"
- irgnore `testGraphviz` inside github workflow tests except for the docker container tests, since only in the docker container case graphviz is available
- add `testMonacoEditorWebJar`: request `loader.js` and check if the server answers with status code 200
- add a note inside the pom where the webjar versions are hard coded inside the project

@arnaudroques you were right. Graphviz is not available inside the workflow tests except for the docker ones.
What do you thing about this (simple) solution?
This will hopefully prevent mistakes like the one described in Issue #290.