### PR TITLE
doc: fix some minor issues (links, order, shortcut)

### DIFF
--- a/docs/WebUI/README.md
+++ b/docs/WebUI/README.md
@@ -21,5 +21,5 @@ You have multiple monitors? You want to share your Window but only show the diag
 
 - [Settings](https://github.com/plantuml/plantuml-server/blob/master/docs/WebUI/settings.md)
 - [PlantUML Language Features](https://github.com/plantuml/plantuml-server/blob/master/docs/WebUI/language-features.md)
-- [Mobile Version](https://github.com/plantuml/plantuml-server/blob/master/docs/WebUI/mobile.md)
 - [Import/Export](https://github.com/plantuml/plantuml-server/blob/master/docs/WebUI/import-export.md)
+- [Mobile Version](https://github.com/plantuml/plantuml-server/blob/master/docs/WebUI/mobile.md)

--- a/docs/WebUI/import-export.md
+++ b/docs/WebUI/import-export.md
@@ -3,7 +3,7 @@
 Similar to [draw.io](https://app.diagrams.net) it is possible to load and continue editing PlantUML diagram images.
 
 
-# Export a diagram
+## Export a diagram
 
 Via the editor menu or <kbd>Ctrl</kbd> + <kbd>S</kbd> (or <kbd>Meta</kbd> + <kbd>S</kbd> in the case of a Mac) you can open the file save dialog.
 Here you can edit the file name, choose a file/diagram type and download the diagram.
@@ -12,7 +12,7 @@ The default is to download the PlantUML code.
 ![export](https://raw.githubusercontent.com/plantuml/plantuml-server/master/docs/WebUI/gifs/diagram-export.gif)
 
 
-# Import a diagram
+## Import a diagram
 
 This feature is based on the PlantUML meta data which currently **support only PNG and SVG** diagrams.
 Besides a diagram image, you can of course also load a diagram code file.

--- a/docs/WebUI/settings.md
+++ b/docs/WebUI/settings.md
@@ -1,5 +1,14 @@
 # Settings
 
+Via the menu or <kbd>Ctrl</kbd> + <kbd>,</kbd> (or <kbd>Meta</kbd> + <kbd>,</kbd> in the case of a Mac) you can open the Setting dialog.
+
+## Theme
+
+_The sun is too bright? You live on the dark side or only in the basement?_
+Choose between the `dark` and `light` theme.
+
+![theme](https://raw.githubusercontent.com/plantuml/plantuml-server/master/docs/WebUI/gifs/settings-theme.gif)
+
 ## Rendering Type
 
 You want always to work and see only the SVG version? Not Problem.  
@@ -7,9 +16,23 @@ Choose the rendering type you want to see.
 
 ![rendering-type](https://raw.githubusercontent.com/plantuml/plantuml-server/master/docs/WebUI/gifs/settings-rendering-type.gif)
 
-## Theme
+## Editor Watcher Timeout
 
-The sun is too bright? You live on the dark side or only in the basement?  
-Choose between the `dark` and `light` theme.
+You can change the Editor Watcher Timeout, by default it is `500 ms`.
 
-![theme](https://raw.githubusercontent.com/plantuml/plantuml-server/master/docs/WebUI/gifs/settings-theme.gif)
+
+## Editor Options
+
+You can change the options of the editor:
+
+```yaml
+{
+  automaticLayout: true,
+  fixedOverflowWidgets: true,
+  minimap: { enabled: false },
+  scrollbar: { alwaysConsumeMouseWheel: false },
+  scrollBeyondLastLine: false,
+  tabSize: 2,
+  theme: "vs",  // "vs-dark"
+}
+```


### PR DESCRIPTION
- [x] Add shortcut (`Ctrl+,`) for Setting dialog on the doc
- [x] Add `Editor Watcher Timeout` and `Editor Options`
- [x] Rearange level of titles and order of links

_FYI @HeinrichAD, from your remark on:_
- https://github.com/plantuml/plantuml-server/pull/294#issuecomment-1560128868
