### PR TITLE
Use package fop-core instead of fop

### DIFF
--- a/pom.parent.xml
+++ b/pom.parent.xml
@@ -82,7 +82,7 @@
     <jlatexmath-font-greek.version>${jlatexmath.version}</jlatexmath-font-greek.version>
     <jlatexmath-font-cyrillic.version>${jlatexmath.version}</jlatexmath-font-cyrillic.version>
     <!-- PDF -->
-    <batik-all.version>1.16</batik-all.version>
+    <batik.version>1.16</batik.version>
     <fop.version>2.8</fop.version>
 
     <!-- Testing -->
@@ -168,23 +168,23 @@
       - batik-dom
       - batik-svgrasterizer (includes batik-dom)
       - batik-svggen
-      - fop
+      - fop-core
     -->
     <dependency>
       <groupId>org.apache.xmlgraphics</groupId>
       <artifactId>batik-svgrasterizer</artifactId>
-      <version>${batik-all.version}</version>
+      <version>${batik.version}</version>
       <scope>runtime</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.xmlgraphics</groupId>
       <artifactId>batik-svggen</artifactId>
-      <version>${batik-all.version}</version>
+      <version>${batik.version}</version>
       <scope>runtime</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.xmlgraphics</groupId>
-      <artifactId>fop</artifactId>
+      <artifactId>fop-core</artifactId>
       <version>${fop.version}</version>
       <scope>runtime</scope>
     </dependency>


### PR DESCRIPTION
Use the `fop-core` package instead of the `fop` package to avoid classpath issues.
This does not seem to be an issue for the PlantUML PDF rendering procedure.

See issue #297.
For a detailed answer and some analysis/tests see https://github.com/plantuml/plantuml-server/issues/297#issuecomment-1585657213.

close #297