### PR TITLE
add security features + java property support

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,12 @@
 
 PlantUML Server is a web application to generate UML diagrams on-the-fly.
 
-[PlantUML is **not** affected by the log4j vulnerability.](https://github.com/plantuml/plantuml/issues/826)
+> [PlantUML is **not** affected by the log4j vulnerability.](https://github.com/plantuml/plantuml/issues/826)
+
+> **Breaking changes**:
+> PlantUML Server sets `PLANTUML_SECURITY_PROFILE` to `INTERNET` by default starting with version `v1.2023.9`.
+> You can change its behavior back to work like before if you set the environment variable `PLANTUML_SECURITY_PROFILE` to `LEGACY`.
+> But before you do that, please take a look to [PlantUMLs Security](https://plantuml.com/security) page.
 
 
 ![PlantUML Server](https://raw.githubusercontent.com/plantuml/plantuml-server/master/docs/screenshot.png)
@@ -119,6 +124,7 @@ You can set all  the following variables:
   * Default value: `ROOT`
 * `PLANTUML_CONFIG_FILE`
   * Local path to a PlantUML configuration file (identical to the `-config` flag on the CLI)
+  * File content will be added before each PlantUML diagram code.
   * Default value: `null`
 * `PLANTUML_LIMIT_SIZE`
   * Limits image width and height
@@ -135,6 +141,13 @@ You can set all  the following variables:
 * `ALLOW_PLANTUML_INCLUDE`
   * Enables `!include` processing which can read files from the server into diagrams. Files are read relative to the current working directory.
   * Default value: `false`
+* `PLANTUML_SECURITY_PROFILE`
+  * Set PlantUML security profile. See [PlantUML security](https://plantuml.com/security).
+  * Default value: `INTERNET`
+* `PLANTUML_PROPERTY_FILE`
+  * Set PlantUML system properties (like over the Java command line using the `-Dpropertyname=value` syntax).
+  * To see what kind of file content is supported, see the documentation of [`java.util.Properties.load`](https://docs.oracle.com/javase/8/docs/api/java/util/Properties.html#load-java.io.Reader-).
+  * Default value: `null`
 
 
 ## Alternate: How to build your docker image

--- a/README.md
+++ b/README.md
@@ -18,11 +18,15 @@ PlantUML Server is a web application to generate UML diagrams on-the-fly.
 
 > [PlantUML is **not** affected by the log4j vulnerability.](https://github.com/plantuml/plantuml/issues/826)
 
-> **Breaking changes**:
-> PlantUML Server sets `PLANTUML_SECURITY_PROFILE` to `INTERNET` by default starting with version `v1.2023.9`.
-> You can change its behavior back to work like before if you set the environment variable `PLANTUML_SECURITY_PROFILE` to `LEGACY`.
-> But before you do that, please take a look to [PlantUMLs Security](https://plantuml.com/security) page.
-
+> **Breaking changes**:  
+> The PlantUML core removed the deprecated `ALLOW_PLANTUML_INCLUDE` environment property feature and switch to the
+> `PLANTUML_SECURITY_PROFILE` concept with version `v1.2023.9`.
+> All details about PlantUML's security can be found on <https://plantuml.com/security>.
+>
+> By default PlantUML server sets the `PLANTUML_SECURITY_PROFILE` to `INTERNET`.
+> If you need more access to e.g. other ports than 80 (http) and 443 (https) or even access to local files, please
+> consider using one of the allowlist features.
+> It is strongly advised **not** to set the `PLANTUML_SECURITY_PROFILE` below `INTERNET`!
 
 ![PlantUML Server](https://raw.githubusercontent.com/plantuml/plantuml-server/master/docs/screenshot.png)
 
@@ -122,6 +126,18 @@ You can set all  the following variables:
 * `BASE_URL`
   * PlantUML Base URL path
   * Default value: `ROOT`
+* `PLANTUML_SECURITY_PROFILE`
+  * Set PlantUML security profile. See [PlantUML security](https://plantuml.com/security).
+  * If you need more access to e.g. other ports than 80 (http) and 443 (https) or even access to local files, please consider using one of the allowlist features:
+    * `plantuml.allowlist.path`
+    * `plantuml.include.path`
+    * `plantuml.allowlist.url`
+  * It is strongly advised **not** to set the `PLANTUML_SECURITY_PROFILE` below `INTERNET`!
+  * Default value: `INTERNET`
+* `PLANTUML_PROPERTY_FILE`
+  * Set PlantUML system properties (like over the Java command line using the `-Dpropertyname=value` syntax).
+  * To see what kind of file content is supported, see the documentation of [`java.util.Properties.load`](https://docs.oracle.com/javase/8/docs/api/java/util/Properties.html#load-java.io.Reader-).
+  * Default value: `null`
 * `PLANTUML_CONFIG_FILE`
   * Local path to a PlantUML configuration file (identical to the `-config` flag on the CLI)
   * File content will be added before each PlantUML diagram code.
@@ -138,16 +154,6 @@ You can set all  the following variables:
 * `HTTP_PROXY_READ_TIMEOUT`
   * when calling the `proxy` endpoint, the value of `HTTP_PROXY_READ_TIMEOUT` will be the connection read timeout in milliseconds
   * Default value: `10000` (10 seconds)
-* `ALLOW_PLANTUML_INCLUDE`
-  * Enables `!include` processing which can read files from the server into diagrams. Files are read relative to the current working directory.
-  * Default value: `false`
-* `PLANTUML_SECURITY_PROFILE`
-  * Set PlantUML security profile. See [PlantUML security](https://plantuml.com/security).
-  * Default value: `INTERNET`
-* `PLANTUML_PROPERTY_FILE`
-  * Set PlantUML system properties (like over the Java command line using the `-Dpropertyname=value` syntax).
-  * To see what kind of file content is supported, see the documentation of [`java.util.Properties.load`](https://docs.oracle.com/javase/8/docs/api/java/util/Properties.html#load-java.io.Reader-).
-  * Default value: `null`
 
 
 ## Alternate: How to build your docker image

--- a/pom.parent.xml
+++ b/pom.parent.xml
@@ -61,7 +61,7 @@
     <jetty.contextpath>/${wtp.contextName}</jetty.contextpath>
 
     <!-- main versions -->
-    <plantuml.version>1.2023.8</plantuml.version>
+    <plantuml.version>1.2023.9</plantuml.version>
     <!-- Please keep the jetty version identical with the docker image -->
     <jetty.version>11.0.15</jetty.version>
     <!--

--- a/src/main/java/net/sourceforge/plantuml/servlet/DiagramResponse.java
+++ b/src/main/java/net/sourceforge/plantuml/servlet/DiagramResponse.java
@@ -39,7 +39,6 @@ import net.sourceforge.plantuml.ErrorUml;
 import net.sourceforge.plantuml.FileFormat;
 import net.sourceforge.plantuml.FileFormatOption;
 import net.sourceforge.plantuml.NullOutputStream;
-import net.sourceforge.plantuml.OptionFlags;
 import net.sourceforge.plantuml.SourceStringReader;
 import net.sourceforge.plantuml.StringUtils;
 import net.sourceforge.plantuml.utils.Base64Coder;

--- a/src/main/java/net/sourceforge/plantuml/servlet/DiagramResponse.java
+++ b/src/main/java/net/sourceforge/plantuml/servlet/DiagramResponse.java
@@ -111,11 +111,6 @@ public class DiagramResponse {
             return;
         }
         initialized = true;
-        // set allow include to false by default
-        OptionFlags.ALLOW_INCLUDE = false;
-        if ("true".equalsIgnoreCase(System.getenv("ALLOW_PLANTUML_INCLUDE"))) {
-            OptionFlags.ALLOW_INCLUDE = true;
-        }
         // set security profile to INTERNET by default
         // NOTE: this property is cached inside PlantUML and cannot be changed after the first call of PlantUML
         System.setProperty("PLANTUML_SECURITY_PROFILE", SecurityProfile.INTERNET.toString());

--- a/src/main/java/net/sourceforge/plantuml/servlet/PlantUmlServlet.java
+++ b/src/main/java/net/sourceforge/plantuml/servlet/PlantUmlServlet.java
@@ -34,7 +34,6 @@ import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 
-import net.sourceforge.plantuml.OptionFlags;
 import net.sourceforge.plantuml.api.PlantumlUtils;
 import net.sourceforge.plantuml.code.NoPlantumlCompressionException;
 import net.sourceforge.plantuml.png.MetadataTag;
@@ -55,6 +54,12 @@ import net.sourceforge.plantuml.servlet.utility.UrlDataExtractor;
 @SuppressWarnings("SERIAL")
 public class PlantUmlServlet extends AsciiCoderServlet {
 
+    static {
+        // Initialize the PlantUML server.
+        // You could say that this is like the `static void main(String[] args)` of the PlantUML server.
+        DiagramResponse.init();
+    }
+
     /**
      * Default encoded uml text.
      * Bob -> Alice : hello
@@ -64,13 +69,6 @@ public class PlantUmlServlet extends AsciiCoderServlet {
     @Override
     protected String getServletContextPath() {
         return "uml";
-    }
-
-    static {
-        OptionFlags.ALLOW_INCLUDE = false;
-        if ("true".equalsIgnoreCase(System.getenv("ALLOW_PLANTUML_INCLUDE"))) {
-            OptionFlags.ALLOW_INCLUDE = true;
-        }
     }
 
     /**

--- a/src/main/java/net/sourceforge/plantuml/servlet/ProxyServlet.java
+++ b/src/main/java/net/sourceforge/plantuml/servlet/ProxyServlet.java
@@ -41,7 +41,6 @@ import jakarta.servlet.http.HttpServletResponse;
 
 import net.sourceforge.plantuml.BlockUml;
 import net.sourceforge.plantuml.FileFormat;
-import net.sourceforge.plantuml.OptionFlags;
 import net.sourceforge.plantuml.SourceStringReader;
 import net.sourceforge.plantuml.core.Diagram;
 import net.sourceforge.plantuml.core.UmlSource;
@@ -53,13 +52,6 @@ import net.sourceforge.plantuml.core.UmlSource;
  */
 @SuppressWarnings("SERIAL")
 public class ProxyServlet extends HttpServlet {
-
-    static {
-        OptionFlags.ALLOW_INCLUDE = false;
-        if ("true".equalsIgnoreCase(System.getenv("ALLOW_PLANTUML_INCLUDE"))) {
-            OptionFlags.ALLOW_INCLUDE = true;
-        }
-    }
 
     public static boolean forbiddenURL(String full) {
         if (full == null) {

--- a/src/main/java/net/sourceforge/plantuml/servlet/UmlDiagramService.java
+++ b/src/main/java/net/sourceforge/plantuml/servlet/UmlDiagramService.java
@@ -34,7 +34,6 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 
 import net.sourceforge.plantuml.FileFormat;
-import net.sourceforge.plantuml.OptionFlags;
 import net.sourceforge.plantuml.servlet.utility.UmlExtractor;
 import net.sourceforge.plantuml.servlet.utility.UrlDataExtractor;
 
@@ -43,13 +42,6 @@ import net.sourceforge.plantuml.servlet.utility.UrlDataExtractor;
  */
 @SuppressWarnings("SERIAL")
 public abstract class UmlDiagramService extends HttpServlet {
-
-    static {
-        OptionFlags.ALLOW_INCLUDE = false;
-        if ("true".equalsIgnoreCase(System.getenv("ALLOW_PLANTUML_INCLUDE"))) {
-            OptionFlags.ALLOW_INCLUDE = true;
-        }
-    }
 
     @Override
     public void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException, ServletException {

--- a/src/main/java/net/sourceforge/plantuml/servlet/utility/UmlExtractor.java
+++ b/src/main/java/net/sourceforge/plantuml/servlet/utility/UmlExtractor.java
@@ -29,7 +29,6 @@ import java.net.URLDecoder;
 
 import net.sourceforge.plantuml.FileFormat;
 import net.sourceforge.plantuml.FileFormatOption;
-import net.sourceforge.plantuml.OptionFlags;
 import net.sourceforge.plantuml.SourceStringReader;
 import net.sourceforge.plantuml.code.Transcoder;
 import net.sourceforge.plantuml.code.TranscoderUtil;
@@ -41,13 +40,6 @@ import net.sourceforge.plantuml.core.ImageData;
  * of the requested URI.
  */
 public abstract class UmlExtractor {
-
-    static {
-        OptionFlags.ALLOW_INCLUDE = false;
-        if ("true".equalsIgnoreCase(System.getenv("ALLOW_PLANTUML_INCLUDE"))) {
-            OptionFlags.ALLOW_INCLUDE = true;
-        }
-    }
 
     /**
      * Build the complete UML source from the compressed source extracted from the

--- a/src/main/webapp/WEB-INF/web.xml
+++ b/src/main/webapp/WEB-INF/web.xml
@@ -71,6 +71,7 @@
   <servlet>
     <servlet-name>plantumlservlet</servlet-name>
     <servlet-class>net.sourceforge.plantuml.servlet.PlantUmlServlet</servlet-class>
+    <load-on-startup>0</load-on-startup>
   </servlet>
   <servlet-mapping>
     <servlet-name>plantumlservlet</servlet-name>


### PR DESCRIPTION
- set `ALLOW_PLANTUML_INCLUDE` only once and decentralized inside the `DiagramResponse` class and call this `init()` method after initializing the server
- set `PLANTUML_SECURITY_PROFILE` to `INTERNET` by default (**BREAKING CHANGES!!!**)
- add possibility to set PlantUML system properties over a file with `PLANTUML_PROPERTY_FILE`
- set `%dirpath()` to current directory if and only if the `PLANTUML_SECURITY_PROFILE` is set to `UNSECURE` (second part of issue #232)
- adjust documentation
- add "Breaking changes" hint to README