### PR TITLE
add "jetty.http.host" property

### DIFF
--- a/src/main/config/jetty.xml
+++ b/src/main/config/jetty.xml
@@ -64,7 +64,8 @@
       </Array>
     </Arg>
 
-    <!-- Change port according to property. Default is 8080 -->
+    <!-- Change host and port according to properties. Default is 0.0.0.0 and 8080. -->
+    <Set name="host"><Property name="jetty.http.host" deprecated="jetty.host" default="0.0.0.0" /></Set>
     <Set name="port"><Property name="jetty.http.port" deprecated="jetty.port" default="8080" /></Set>
   </New>
 


### PR DESCRIPTION
Currently, the server connector uses 0.0.0.0 as fallback and always binds to all interfaces.

Add the possibility to set the network interface the Jetty server connector binds to as an IP address or a hostname. If null or 0.0.0.0, then its automatically binds to all interfaces.

These changes are based on a feature request and closes #161.

References:
- <https://eclipse.dev/jetty/javadoc/jetty-11/org/eclipse/jetty/server/AbstractNetworkConnector.html#getHost()>