### PR TITLE
Set `java.awt.headless` to `true` due to Windows 11 issues

### DIFF
--- a/src/main/java/net/sourceforge/plantuml/servlet/DiagramResponse.java
+++ b/src/main/java/net/sourceforge/plantuml/servlet/DiagramResponse.java
@@ -121,6 +121,10 @@ public class DiagramResponse {
             return;
         }
         initialized = true;
+        // set headless mode manually since otherwise Windows 11 seems to have some issues with it
+        // see Issue#311 :: https://github.com/plantuml/plantuml-server/issues/311
+        // NOTE: This can only be set before any awt/X11/... related stuff is loaded
+        System.setProperty("java.awt.headless", "true");
         // set security profile to INTERNET by default
         // NOTE: this property is cached inside PlantUML and cannot be changed after the first call of PlantUML
         System.setProperty("PLANTUML_SECURITY_PROFILE", SecurityProfile.INTERNET.toString());

--- a/src/main/java/net/sourceforge/plantuml/servlet/DiagramResponse.java
+++ b/src/main/java/net/sourceforge/plantuml/servlet/DiagramResponse.java
@@ -124,7 +124,7 @@ public class DiagramResponse {
         // set headless mode manually since otherwise Windows 11 seems to have some issues with it
         // see Issue#311 :: https://github.com/plantuml/plantuml-server/issues/311
         // NOTE: This can only be set before any awt/X11/... related stuff is loaded
-        System.setProperty("java.awt.headless", "true");
+        System.setProperty("java.awt.headless", System.getProperty("java.awt.headless", "true"));
         // set security profile to INTERNET by default
         // NOTE: this property is cached inside PlantUML and cannot be changed after the first call of PlantUML
         System.setProperty("PLANTUML_SECURITY_PROFILE", SecurityProfile.INTERNET.toString());


### PR DESCRIPTION
This issue should prevent X11 errors in Windows 11 like e.g. issue #311 by forcing the PlantUML server to run `java.awt` to run in headless mode.

closes #311