### PR TITLE
Updated Jetty and JRE in Docker, fixed Alpine build

### DIFF
--- a/Dockerfile.jetty
+++ b/Dockerfile.jetty
@@ -1,4 +1,4 @@
-FROM maven:3-eclipse-temurin-11 AS builder
+FROM maven:3-eclipse-temurin-17 AS builder
 
 COPY pom.xml pom.parent.xml /app/
 COPY src/main /app/src/main/
@@ -8,7 +8,7 @@ RUN mvn --batch-mode --define java.net.useSystemProxies=true package
 
 ########################################################################################
 
-FROM jetty:11.0.15-jre11
+FROM jetty:11.0.18-jre17-eclipse-temurin
 
 # Proxy and OldProxy need empty path segments support in URIs
 # Hence: allow AMBIGUOUS_EMPTY_SEGMENT

--- a/Dockerfile.jetty-alpine
+++ b/Dockerfile.jetty-alpine
@@ -1,4 +1,4 @@
-FROM maven:3-eclipse-temurin-11-alpine AS builder
+FROM maven:3-eclipse-temurin-17-alpine AS builder
 
 COPY pom.xml pom.parent.xml /app/
 COPY src/main /app/src/main/
@@ -8,7 +8,7 @@ RUN mvn --batch-mode --define java.net.useSystemProxies=true package
 
 ########################################################################################
 
-FROM jetty:11.0.15-jre11-alpine-eclipse-temurin
+FROM jetty:11.0.18-jre17-alpine-eclipse-temurin
 
 # Proxy and OldProxy need empty path segments support in URIs
 # Hence: allow AMBIGUOUS_EMPTY_SEGMENT
@@ -30,9 +30,10 @@ ARG GRAPHVIZ_BUILD_DIR=/tmp/graphiz-build
 RUN apk add --no-cache \
         g++ \
         jq \
-        libexpat \
+        expat-dev \
         make \
         zlib \
+        pkgconf \
         && \
     mkdir -p $GRAPHVIZ_BUILD_DIR && \
     cd $GRAPHVIZ_BUILD_DIR && \
@@ -46,7 +47,7 @@ RUN apk add --no-cache \
     apk del --no-cache \
         g++ \
         jq \
-        libexpat \
+        expat-dev \
         make \
         zlib \
         && \

--- a/pom.parent.xml
+++ b/pom.parent.xml
@@ -63,7 +63,7 @@
     <!-- main versions -->
     <plantuml.version>1.2023.12</plantuml.version>
     <!-- Please keep the jetty version identical with the docker image -->
-    <jetty.version>11.0.15</jetty.version>
+    <jetty.version>11.0.18</jetty.version>
     <!--
       While changing the version, please update the versions in the following files as well:
       - src/main/webapp/components/app-head.jsp (script import)


### PR DESCRIPTION
I've updated the Jetty Server to 11.0.18, switched the JRE Runtime to Eclipse Temurin 17 for the Docker images (both Debian and Alpine) and fixed compilation errors for the Alpine Linux version