### PR TITLE
Change image tag from jetty-local to jetty

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,7 @@ services:
     build:
       context: .
       dockerfile: Dockerfile.jetty
-    image: plantuml/plantuml-server:jetty-local
+    image: plantuml/plantuml-server:jetty
     container_name: plantuml-server
     ports:
       - 8080:8080


### PR DESCRIPTION
Fix docker compose as jetty-local image does not exist anymore.

`Error response from daemon: manifest for plantuml/plantuml-server:jetty-local not found: manifest unknown: manifest unknown`