### PR TITLE
fix README.md example

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ In this way the server is run on an embedded jetty server.
 You can specify the port at which it runs:
 
 ```sh
-mvn jetty:run -Djetty.http.port=9999
+mvn jetty:run -D jetty.http.port=9999
 ```
 
 


### PR DESCRIPTION
The second example in README.md has minor typo which may cause confusion:

```
mvn jetty:run -Djetty.http.port=9999
```

notice there is no space between the `-D` option and the value, shall be updatd with:

```
mvn jetty:run -D jetty.http.port=9999
```