### PR TITLE
build: update jetty images from patch level 18 to 24

### DIFF
--- a/Dockerfile.jetty
+++ b/Dockerfile.jetty
@@ -8,7 +8,7 @@ RUN mvn --batch-mode --define java.net.useSystemProxies=true package
 
 ########################################################################################
 
-FROM jetty:11.0.18-jre17-eclipse-temurin
+FROM jetty:11.0.24-jre17-eclipse-temurin
 
 # Proxy and OldProxy need empty path segments support in URIs
 # Hence: allow AMBIGUOUS_EMPTY_SEGMENT

--- a/Dockerfile.jetty-alpine
+++ b/Dockerfile.jetty-alpine
@@ -8,7 +8,7 @@ RUN mvn --batch-mode --define java.net.useSystemProxies=true package
 
 ########################################################################################
 
-FROM jetty:11.0.18-jre17-alpine-eclipse-temurin
+FROM jetty:11.0.24-jre17-alpine-eclipse-temurin
 
 # Proxy and OldProxy need empty path segments support in URIs
 # Hence: allow AMBIGUOUS_EMPTY_SEGMENT


### PR DESCRIPTION
We get security alerts due to outdated layer/packages in the base ubuntu layer of the plantuml-server images.
Also jetty itself got several patch releases:
https://github.com/jetty/jetty.project/releases/tag/jetty-11.0.19
https://github.com/jetty/jetty.project/releases/tag/jetty-11.0.20
https://github.com/jetty/jetty.project/releases/tag/jetty-11.0.21
https://github.com/jetty/jetty.project/releases/tag/jetty-11.0.22
https://github.com/jetty/jetty.project/releases/tag/jetty-11.0.23
https://github.com/jetty/jetty.project/releases/tag/jetty-11.0.24
