### PR TITLE
fix: remove broken tests based on jetty-runner

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -35,42 +35,6 @@ jobs:
           path: target/plantuml.war
           retention-days: 1
 
-  test-java-8-war:
-    runs-on: ubuntu-latest
-    needs: test-java-8-war-generation
-    strategy:
-      matrix:
-        java-version: [ 11, 17 ]
-    steps:
-      - uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
-
-      - name: retrieve generated files (jre8)
-        uses: actions/download-artifact@v4.1.7
-        with:
-          name: war-jre8
-          path: artifacts
-
-      - uses: actions/setup-java@v3
-        with:
-          distribution: "zulu"
-          java-version: ${{ matrix.java-version }}
-          check-latest: true
-          cache: "maven"
-
-      - name: Prepare jetty-runner tests
-        run: mvn --batch-mode clean package
-
-      - name: Start jetty server over jetty-runner
-        run: java -jar target/dependency/jetty-runner.jar --config src/main/config/jetty.xml --path /plantuml artifacts/plantuml.war &
-
-      - name: Wait 5 seconds (to let jetty-runner start the jetty server)
-        run: sleep 5s
-
-      - name: Run tests against "mvn jetty:run" server
-        run: mvn --batch-mode test -DskipTests=false -Dgroups=\!graphviz-test -DargLine="-Dsystem.test.server=http://localhost:8080/plantuml"
-
   test-mvn-livecycle:
     runs-on: ubuntu-latest
     strategy:
@@ -159,36 +123,6 @@ jobs:
 
       - name: Wait 20 seconds (to let maven start the jetty server)
         run: sleep 20s
-
-      - name: Run tests against "mvn jetty:run" server
-        run: mvn --batch-mode test -DskipTests=false -Dgroups=\!graphviz-test -DargLine="-Dsystem.test.server=http://localhost:8080/plantuml"
-
-  test-jetty-runner:
-    runs-on: ubuntu-latest
-    needs: test-mvn-livecycle
-    strategy:
-      matrix:
-        java-version: [ 11, 17 ]
-    steps:
-      - uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
-
-      - uses: actions/setup-java@v3
-        with:
-          distribution: "zulu"
-          java-version: ${{ matrix.java-version }}
-          check-latest: true
-          cache: "maven"
-
-      - name: Prepare jetty-runner tests
-        run: mvn --batch-mode clean package
-
-      - name: Start jetty server over jetty-runner
-        run: java -jar target/dependency/jetty-runner.jar --config src/main/config/jetty.xml --path /plantuml target/plantuml.war &
-
-      - name: Wait 5 seconds (to let jetty-runner start the jetty server)
-        run: sleep 5s
 
       - name: Run tests against "mvn jetty:run" server
         run: mvn --batch-mode test -DskipTests=false -Dgroups=\!graphviz-test -DargLine="-Dsystem.test.server=http://localhost:8080/plantuml"

--- a/README.md
+++ b/README.md
@@ -98,20 +98,7 @@ And run `docker-compose up`. This will start a modified version of the image usi
 
 You can apply some option to your PlantUML server with environment variable.
 
-If you run the directly the jar:
-```sh
-# NOTE: jetty-runner is deprecated.
-# build war file and jetty-runner
-mvn package
-# start directly
-# java $JVM_ARGS -jar jetty-runner.jar $JETTY_ARGS
-java -jar target/dependency/jetty-runner.jar --config src/main/config/jetty.xml --port 9999 --path /plantuml target/plantuml.war
-# see help for more possible options
-java -jar target/dependency/jetty-runner.jar --help
-```
-Note: `--config src/main/config/jetty.xml` is only necessary if you need support for empty path segments in URLs (e.g. for the old proxy)
-
-Alternatively, start over maven and pass the option with `-D` flag
+If you're using the `jetty` Maven plugin, use the -D` flag to pass environment variables:
 ```sh
 mvn jetty:run -D THE_ENV_VARIABLE=THE_ENV_VALUE -Djetty.http.port=9999
 ```

--- a/pom.parent.xml
+++ b/pom.parent.xml
@@ -41,7 +41,7 @@
       This artifact is required for:
         1. EmbeddedJettyServer -> scope: test
         2. Tomcat docker image -> scope: compile
-      BUT: Jetty docker image as well as jetty-runner will crash on runtime if
+      BUT: Jetty docker image will crash on runtime if
            this artifact is included because it's already provided so that the
            artifact would apear multiple times on the classpath.
            You can test it via: `mvn jetty:run [-Dapache-jsp.scope=compile]`
@@ -63,7 +63,7 @@
     <!-- main versions -->
     <plantuml.version>1.2025.0</plantuml.version>
     <!-- Please keep the jetty version identical with the docker image -->
-    <jetty.version>11.0.18</jetty.version>
+    <jetty.version>11.0.24</jetty.version>
     <!--
       While changing the version, please update the versions in the following files as well:
       - src/main/webapp/components/app-head.jsp (script import)
@@ -111,7 +111,6 @@
 
     <!-- plugins -->
     <maven-eclipse-plugin.version>2.10</maven-eclipse-plugin.version>
-    <jetty-runner.version>${jetty.version}</jetty-runner.version>
     <jetty-maven-plugin.version>${jetty.version}</jetty-maven-plugin.version>
     <duplicate-finder-maven-plugin.version>1.5.1</duplicate-finder-maven-plugin.version>
     <maven-javadoc-plugin.version>3.5.0</maven-javadoc-plugin.version>
@@ -437,23 +436,6 @@
                   <version>${monaco-editor.version}</version>
                   <includes>**/min/vs/loader.js,**/min/vs/**/*,**/min-maps/vs/**/*</includes>
                   <outputDirectory>${project.build.outputDirectory}</outputDirectory>
-                </artifactItem>
-              </artifactItems>
-            </configuration>
-          </execution>
-          <!-- provide jetty-runner -->
-          <execution>
-            <phase>package</phase>
-            <goals>
-              <goal>copy</goal>
-            </goals>
-            <configuration>
-              <artifactItems>
-                <artifactItem>
-                  <groupId>org.eclipse.jetty</groupId>
-                  <artifactId>jetty-runner</artifactId>
-                  <version>${jetty-runner.version}</version>
-                  <destFileName>jetty-runner.jar</destFileName>
                 </artifactItem>
               </artifactItems>
             </configuration>


### PR DESCRIPTION
* tests based on jetty-runner do not work because the jetty-runner JAR contains invalid Java SPI services config files
* due to these invalid files Jetty 11.0.20+ is unable to properly initialize itself itself
* This change removes all tests based on jetty-runner and bumps the Jetty version to 11.0.24
* There are already jobs using the Jetty Maven plugin to launch a testing instance + run all tests