### PR TITLE
chore(deps): pin graphviz version in Dockerfiles

### DIFF
--- a/Dockerfile.jetty
+++ b/Dockerfile.jetty
@@ -26,8 +26,8 @@ RUN apt-get update && \
     rm -rf /var/lib/apt/lists/* && \
     /generate-jetty-start.sh
 
+ARG GRAPHVIZ_VERSION=14.0.1
 # Build Graphviz from source because there are no binary distributions for recent versions
-ARG GRAPHVIZ_VERSION
 ARG GRAPHVIZ_BUILD_DIR=/tmp/graphiz-build
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
@@ -39,7 +39,6 @@ RUN apt-get update && \
         && \
     mkdir -p $GRAPHVIZ_BUILD_DIR && \
     cd $GRAPHVIZ_BUILD_DIR && \
-    GRAPHVIZ_VERSION=${GRAPHVIZ_VERSION:-$(curl -s https://gitlab.com/api/v4/projects/4207231/releases/ | jq -r '.[] | .name' | sort -V -r | head -1)} && \
     curl -o graphviz.tar.gz https://gitlab.com/api/v4/projects/4207231/packages/generic/graphviz-releases/${GRAPHVIZ_VERSION}/graphviz-${GRAPHVIZ_VERSION}.tar.gz && \
     tar -xzf graphviz.tar.gz && \
     cd graphviz-$GRAPHVIZ_VERSION && \

--- a/Dockerfile.jetty-alpine
+++ b/Dockerfile.jetty-alpine
@@ -24,8 +24,8 @@ RUN apk add --no-cache \
         && \
     /generate-jetty-start.sh
 
-#RUN apk add --no-cache graphviz
-ARG GRAPHVIZ_VERSION
+ARG GRAPHVIZ_VERSION=14.0.1
+# Build Graphviz from source because there are no binary distributions for recent versions
 ARG GRAPHVIZ_BUILD_DIR=/tmp/graphiz-build
 RUN apk add --no-cache \
         g++ \
@@ -37,7 +37,6 @@ RUN apk add --no-cache \
         && \
     mkdir -p $GRAPHVIZ_BUILD_DIR && \
     cd $GRAPHVIZ_BUILD_DIR && \
-    GRAPHVIZ_VERSION=${GRAPHVIZ_VERSION:-$(curl -s https://gitlab.com/api/v4/projects/4207231/releases/ | jq -r '.[] | .name' | sort -V -r | head -1)} && \
     curl -o graphviz.tar.gz https://gitlab.com/api/v4/projects/4207231/packages/generic/graphviz-releases/${GRAPHVIZ_VERSION}/graphviz-${GRAPHVIZ_VERSION}.tar.gz && \
     tar -xzf graphviz.tar.gz && \
     cd graphviz-$GRAPHVIZ_VERSION && \

--- a/Dockerfile.tomcat
+++ b/Dockerfile.tomcat
@@ -18,8 +18,8 @@ RUN apt-get update && \
         && \
     rm -rf /var/lib/apt/lists/*
 
+ARG GRAPHVIZ_VERSION=14.0.1
 # Build Graphviz from source because there are no binary distributions for recent versions
-ARG GRAPHVIZ_VERSION
 ARG GRAPHVIZ_BUILD_DIR=/tmp/graphiz-build
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
@@ -31,7 +31,6 @@ RUN apt-get update && \
         && \
     mkdir -p $GRAPHVIZ_BUILD_DIR && \
     cd $GRAPHVIZ_BUILD_DIR && \
-    GRAPHVIZ_VERSION=${GRAPHVIZ_VERSION:-$(curl -s https://gitlab.com/api/v4/projects/4207231/releases/ | jq -r '.[] | .name' | sort -V -r | head -1)} && \
     curl -o graphviz.tar.gz https://gitlab.com/api/v4/projects/4207231/packages/generic/graphviz-releases/${GRAPHVIZ_VERSION}/graphviz-${GRAPHVIZ_VERSION}.tar.gz && \
     tar -xzf graphviz.tar.gz && \
     cd graphviz-$GRAPHVIZ_VERSION && \


### PR DESCRIPTION
Contributes to https://github.com/plantuml/plantuml-server/issues/393

Tested locally for the 3 Dockerfiles.

- Without specifying a version for `graphviz`

```sh
docker image build -f Dockerfile.jetty -t plantuml-server/jetty .
docker run -p 8080:8080 -it plantuml-server/jetty
```

- By setting a specific version for `graphviz`

```sh
docker image build -f Dockerfile.jetty -build-arg GRAPHVIZ_VERSION=14.0.0 -t plantuml-server/jetty .
docker run -p 8080:8080 -it plantuml-server/jetty
```