### PR TITLE
Upgrade Jetty to 12.1

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,7 +6,7 @@ on:
       - "v*"
 
 jobs:
-  build-jdk11:
+  build-jdk17:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -16,7 +16,7 @@ jobs:
       - uses: actions/setup-java@v3
         with:
           distribution: "zulu"
-          java-version: 11
+          java-version: 17
           check-latest: true
           cache: "maven"
 
@@ -39,18 +39,18 @@ jobs:
       - name: temporarily save generated war files
         uses: actions/upload-artifact@v4
         with:
-          name: war-jre11
+          name: war-jre17
           path: target/plantuml*-${{ steps.version.outputs.VERSION }}.war
 
   publish-releases:
     runs-on: ubuntu-latest
     needs:
-      - build-jdk11
+      - build-jdk17
     steps:
       - name: retrieve generated war files
         uses: actions/download-artifact@v4.1.7
         with:
-          name: war-jre11
+          name: war-jre17
           path: artifacts
 
       - name: display structure of downloaded files
@@ -147,7 +147,7 @@ jobs:
       - uses: actions/setup-java@v3
         with:
           distribution: "zulu"
-          java-version: 11
+          java-version: 17
           check-latest: true
           cache: "maven"
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        java-version: [ 11, 17 ]
+        java-version: [ 17, 21, 25 ]
     steps:
       - uses: actions/checkout@v3
         with:
@@ -51,7 +51,7 @@ jobs:
     needs: test-mvn-livecycle
     strategy:
       matrix:
-        java-version: [ 11, 17 ]
+        java-version: [ 17, 21, 25 ]
     steps:
       - uses: actions/checkout@v3
         with:
@@ -72,7 +72,7 @@ jobs:
     needs: test-mvn-livecycle
     strategy:
       matrix:
-        java-version: [ 11, 17 ]
+        java-version: [ 17, 21, 25 ]
     steps:
       - uses: actions/checkout@v3
         with:
@@ -102,7 +102,7 @@ jobs:
     needs: test-mvn-livecycle
     strategy:
       matrix:
-        java-version: [ 11, 17 ]
+        java-version: [ 17, 21, 25 ]
     steps:
       - uses: actions/checkout@v3
         with:
@@ -134,7 +134,7 @@ jobs:
     needs: test-mvn-livecycle
     strategy:
       matrix:
-        java-version: [ 11, 17 ]
+        java-version: [ 17, 21, 25 ]
     steps:
       - uses: actions/checkout@v3
         with:

--- a/Dockerfile.jetty
+++ b/Dockerfile.jetty
@@ -8,12 +8,14 @@ RUN mvn --batch-mode --define java.net.useSystemProxies=true package
 
 ########################################################################################
 
-FROM jetty:11.0.24-jre17-eclipse-temurin
+FROM jetty:12.1.6-jdk17-eclipse-temurin
+
+RUN java -jar "$JETTY_HOME/start.jar" --add-modules=ee11-deploy,ee11-annotations,ee11-jsp,ee11-jstl
 
 # Proxy and OldProxy need empty path segments support in URIs
 # Hence: allow AMBIGUOUS_EMPTY_SEGMENT
 # Changes are only active if `/generate-jetty-start.sh` is called!
-RUN sed -i 's/# jetty\.httpConfig\.uriCompliance=DEFAULT/jetty.httpConfig.uriCompliance=DEFAULT,AMBIGUOUS_EMPTY_SEGMENT/g' /var/lib/jetty/start.d/server.ini
+RUN echo "jetty.httpConfig.uriCompliance=DEFAULT,AMBIGUOUS_EMPTY_SEGMENT" >> /var/lib/jetty/start.d/server.ini
 
 USER root
 

--- a/Dockerfile.jetty-alpine
+++ b/Dockerfile.jetty-alpine
@@ -8,12 +8,14 @@ RUN mvn --batch-mode --define java.net.useSystemProxies=true package
 
 ########################################################################################
 
-FROM jetty:11.0.26-jre17-alpine-eclipse-temurin
+FROM jetty:12.1.6-jdk17-alpine-eclipse-temurin
+
+RUN java -jar "$JETTY_HOME/start.jar" --add-modules=ee11-deploy,ee11-annotations,ee11-jsp,ee11-jstl
 
 # Proxy and OldProxy need empty path segments support in URIs
 # Hence: allow AMBIGUOUS_EMPTY_SEGMENT
 # Changes are only active if `/generate-jetty-start.sh` is called!
-RUN sed -i 's/# jetty\.httpConfig\.uriCompliance=DEFAULT/jetty.httpConfig.uriCompliance=DEFAULT,AMBIGUOUS_EMPTY_SEGMENT/g' /var/lib/jetty/start.d/server.ini
+RUN echo "jetty.httpConfig.uriCompliance=DEFAULT,AMBIGUOUS_EMPTY_SEGMENT" >> /var/lib/jetty/start.d/server.ini
 
 USER root
 

--- a/Dockerfile.tomcat
+++ b/Dockerfile.tomcat
@@ -1,4 +1,4 @@
-FROM maven:3-eclipse-temurin-11 AS builder
+FROM maven:3-eclipse-temurin-17 AS builder
 
 COPY pom.xml pom.parent.xml /app/
 COPY src/main /app/src/main/
@@ -8,7 +8,7 @@ RUN mvn --batch-mode --define java.net.useSystemProxies=true -Dapache-jsp.scope=
 
 ########################################################################################
 
-FROM tomcat:10-jdk11
+FROM tomcat:11-jdk17
 
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \

--- a/README.md
+++ b/README.md
@@ -37,13 +37,13 @@ To know more about PlantUML, please visit https://plantuml.com.
 
 ## Requirements
 
-- jre/jdk 11 or above
+- jre/jdk 17 or above
 - apache maven 3.0.2 or above
 
 ## Recommendations
 
-- Jetty 11 or above
-- Tomcat 10 or above
+- Jetty 12.1 or above
+- Tomcat 11 or above
 
 
 ## How to run the server
@@ -123,7 +123,7 @@ You can set all  the following variables:
   * Default value: `INTERNET`
 * `PLANTUML_PROPERTY_FILE`
   * Set PlantUML system properties (like over the Java command line using the `-Dpropertyname=value` syntax).
-  * To see what kind of file content is supported, see the documentation of [`java.util.Properties.load`](https://docs.oracle.com/javase/8/docs/api/java/util/Properties.html#load-java.io.Reader-).
+  * To see what kind of file content is supported, see the documentation of [`java.util.Properties.load`](https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/util/Properties.html#load(java.io.Reader)).
   * Default value: `null`
 * `PLANTUML_CONFIG_FILE`
   * Local path to a PlantUML configuration file (identical to the `-config` flag on the CLI)
@@ -170,11 +170,6 @@ NOTE: If you want that the generated war includes the `apache-jsp` artifact run:
 mvn package -Dapache-jsp.scope=compile
 ```
 
-If you want to generate the war with java 8 as target just remove the src/test directory and use `pom.jdk8.xml`.
-```sh
-rm -rf src/test
-mvn package -f pom.jdk8.xml [-Dapache-jsp.scope=compile]
-```
 
 ## Use with reverse-proxy
 

--- a/ROOT.jetty.xml
+++ b/ROOT.jetty.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://www.eclipse.org/jetty/configure_10_0.dtd">
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_10_0.dtd">
 
-<Configure class="org.eclipse.jetty.webapp.WebAppContext">
+<Configure class="org.eclipse.jetty.ee11.webapp.WebAppContext">
   <Set name="contextPath">
     <Env name="CONTEXT_PATH" />
   </Set>

--- a/pom.parent.xml
+++ b/pom.parent.xml
@@ -45,7 +45,7 @@
            this artifact is included because it's already provided so that the
            artifact would apear multiple times on the classpath.
            You can test it via: `mvn jetty:run [-Dapache-jsp.scope=compile]`
-           Error: java.util.ServiceConfigurationError: org.apache.juli.logging.Log: org.eclipse.jetty.apache.jsp.JuliLog not a subtype
+           Error: java.util.ServiceConfigurationError: org.apache.juli.logging.Log: org.eclipse.jetty.ee11.apache.jsp.JuliLog not a subtype
       HENCE: Default is the "test" scope and for Tomcat docker image building add:
         -Dapache-jsp.scope=compile
     -->
@@ -63,7 +63,7 @@
     <!-- main versions -->
     <plantuml.version>1.2026.2</plantuml.version>
     <!-- Please keep the jetty version identical with the docker image -->
-    <jetty.version>11.0.24</jetty.version>
+    <jetty.version>12.1.6</jetty.version>
     <!--
       While changing the version, please update the versions in the following files as well:
       - src/main/webapp/components/app-head.jsp (script import)
@@ -73,7 +73,7 @@
     <monaco-editor.version>0.36.1</monaco-editor.version>
 
     <!-- dependencies -->
-    <jstl.version>1.2</jstl.version>
+    <jakarta-servlet.version>6.1.0</jakarta-servlet.version>
     <apache-jsp.version>${jetty.version}</apache-jsp.version>
     <jetty-annotations.version>${jetty.version}</jetty-annotations.version>
     <glassfish-jstl.version>${jetty.version}</glassfish-jstl.version>
@@ -132,16 +132,34 @@
       <scope>runtime</scope>
     </dependency>
     <dependency>
-      <groupId>org.eclipse.jetty</groupId>
-      <artifactId>apache-jsp</artifactId>
+      <groupId>jakarta.servlet</groupId>
+      <artifactId>jakarta.servlet-api</artifactId>
+      <version>${jakarta-servlet.version}</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.eclipse.jetty.ee11</groupId>
+      <artifactId>jetty-ee11-apache-jsp</artifactId>
       <version>${apache-jsp.version}</version>
       <scope>${apache-jsp.scope}</scope>
     </dependency>
     <dependency>
-      <groupId>org.eclipse.jetty</groupId>
-      <artifactId>jetty-annotations</artifactId>
+      <groupId>org.eclipse.jetty.ee11</groupId>
+      <artifactId>jetty-ee11-annotations</artifactId>
       <version>${jetty-annotations.version}</version>
       <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.eclipse.jetty.ee11</groupId>
+      <artifactId>jetty-ee11-glassfish-jstl</artifactId>
+      <version>${glassfish-jstl.version}</version>
+      <scope>runtime</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>jakarta.el</groupId>
+          <artifactId>jakarta.el-api</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <!-- jlatexmath -->
     <dependency>
@@ -223,6 +241,12 @@
       <groupId>org.eclipse.jetty</groupId>
       <artifactId>jetty-server</artifactId>
       <version>${jetty-server.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.eclipse.jetty.ee11</groupId>
+      <artifactId>jetty-ee11-webapp</artifactId>
+      <version>${jetty.version}</version>
       <scope>test</scope>
     </dependency>
 	<dependency>
@@ -454,8 +478,8 @@
       </plugin>
       <!-- configure jetty -->
       <plugin>
-        <groupId>org.eclipse.jetty</groupId>
-        <artifactId>jetty-maven-plugin</artifactId>
+        <groupId>org.eclipse.jetty.ee11</groupId>
+        <artifactId>jetty-ee11-maven-plugin</artifactId>
         <version>${jetty-maven-plugin.version}</version>
         <configuration>
           <!-- jetty.xml
@@ -464,7 +488,7 @@
             Hence: allow AMBIGUOUS_EMPTY_SEGMENT
           -->
           <jettyXmls>${basedir}/src/main/config/jetty.xml</jettyXmls>
-          <scanIntervalSeconds>5</scanIntervalSeconds>
+          <scan>5</scan>
           <webApp>
             <contextPath>${jetty.contextpath}</contextPath>
           </webApp>

--- a/pom.xml
+++ b/pom.xml
@@ -17,6 +17,6 @@
   <packaging>war</packaging>
 
   <properties>
-    <java.version>11</java.version>
+    <java.version>17</java.version>
   </properties>
 </project>

--- a/src/main/config/jetty.xml
+++ b/src/main/config/jetty.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://www.eclipse.org/jetty/configure_10_0.dtd">
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_10_0.dtd">
 
 <!-- =============================================================== -->
 <!-- Configure a Jetty Server instance with an ID "Server"           -->

--- a/src/main/webapp/WEB-INF/web.xml
+++ b/src/main/webapp/WEB-INF/web.xml
@@ -2,9 +2,8 @@
 <web-app
   xmlns="https://jakarta.ee/xml/ns/jakartaee"
   xmlns:xsi="https://www.w3.org/2001/XMLSchema-instance"
-  xmlns:web="https://jakarta.ee/xml/ns/jakartaee/web-app_5_0.xsd"
-  xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/web-app_5_0.xsd"
-  version="5.0"
+  xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/web-app_6_1.xsd"
+  version="6.1"
 >
 
   <!-- ========================================================== -->
@@ -34,7 +33,7 @@
   <!--
   <jsp-config>
     <taglib>
-      <taglib-uri>http://java.sun.com/jsp/jstl/core</taglib-uri>
+      <taglib-uri>jakarta.tags.core</taglib-uri>
       <taglib-location>/WEB-INF/lib/c.tld</taglib-location>
     </taglib>
   </jsp-config>
@@ -57,14 +56,14 @@
 
   <servlet>
     <servlet-name>jsp</servlet-name>
-    <servlet-class>org.eclipse.jetty.jsp.JettyJspServlet</servlet-class>
+    <servlet-class>org.eclipse.jetty.ee11.jsp.JettyJspServlet</servlet-class>
     <init-param>
       <param-name>compilerSourceVM</param-name>
-      <param-value>1.8</param-value>
+      <param-value>17</param-value>
     </init-param>
     <init-param>
       <param-name>compilerTargetVM</param-name>
-      <param-value>1.8</param-value>
+      <param-value>17</param-value>
     </init-param>
   </servlet>
 

--- a/src/main/webapp/error.jsp
+++ b/src/main/webapp/error.jsp
@@ -1,5 +1,5 @@
 <%@ page isErrorPage="true" contentType="text/html; charset=utf-8" pageEncoding="utf-8" session="false" %>
-<%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c" %>
+<%@ taglib uri="jakarta.tags.core" prefix="c" %>
 
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml">

--- a/src/test/java/net/sourceforge/plantuml/servlet/server/EmbeddedJettyServer.java
+++ b/src/test/java/net/sourceforge/plantuml/servlet/server/EmbeddedJettyServer.java
@@ -2,14 +2,14 @@ package net.sourceforge.plantuml.servlet.server;
 
 import java.util.EnumSet;
 
+import org.eclipse.jetty.ee11.webapp.WebAppContext;
 import org.eclipse.jetty.http.UriCompliance;
 import org.eclipse.jetty.http.UriCompliance.Violation;
+import org.eclipse.jetty.server.Handler;
 import org.eclipse.jetty.server.HttpConnectionFactory;
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.server.ServerConnector;
 import org.eclipse.jetty.server.handler.DefaultHandler;
-import org.eclipse.jetty.server.handler.HandlerList;
-import org.eclipse.jetty.webapp.WebAppContext;
 
 public class EmbeddedJettyServer implements ServerUtils {
 
@@ -30,20 +30,19 @@ public class EmbeddedJettyServer implements ServerUtils {
         server.addConnector(connector);
 
         // PlantUML server web application
-        WebAppContext context = new WebAppContext(server, "src/main/webapp", EmbeddedJettyServer.contextPath);
+        WebAppContext context = new WebAppContext("src/main/webapp", EmbeddedJettyServer.contextPath);
         context.addVirtualHosts(virtualHosts);
 
         // Add static webjars resource files
         // The maven-dependency-plugin in the pom.xml provides these files.
         WebAppContext res = new WebAppContext(
-            server,
             "target/classes/META-INF/resources/webjars",
             EmbeddedJettyServer.contextPath + "/webjars"
         );
         res.addVirtualHosts(virtualHosts);
 
         // Create server handler
-        HandlerList handlers = new HandlerList();
+        Handler.Sequence handlers = new Handler.Sequence();
         handlers.addHandler(res);                   // provides: /plantuml/webjars
         handlers.addHandler(context);               // provides: /plantuml
         handlers.addHandler(new DefaultHandler());  // provides: /


### PR DESCRIPTION
Jetty 11 reached end of life on January 1, 2025 (https://github.com/jetty/jetty.project/issues/10485)
Jetty 12 requires Java 17+ and targets Jakarta EE 11.